### PR TITLE
Fix CallMsgFromTx()

### DIFF
--- a/decode.go
+++ b/decode.go
@@ -241,11 +241,20 @@ func (m *Client) DecodeCustomABIErr(txErr error) (string, error) {
 
 // CallMsgFromTx creates ethereum.CallMsg from tx, used in simulated calls
 func (m *Client) CallMsgFromTx(tx *types.Transaction) ethereum.CallMsg {
+	if tx.Type() == types.LegacyTxType {
+		return ethereum.CallMsg{
+			From:     m.Addresses[0],
+			To:       tx.To(),
+			Gas:      tx.Gas(),
+			GasPrice: tx.GasPrice(),
+			Value:    tx.Value(),
+			Data:     tx.Data(),
+		}
+	}
 	return ethereum.CallMsg{
 		From:      m.Addresses[0],
 		To:        tx.To(),
 		Gas:       tx.Gas(),
-		GasPrice:  tx.GasPrice(),
 		GasFeeCap: tx.GasFeeCap(),
 		GasTipCap: tx.GasTipCap(),
 		Value:     tx.Value(),


### PR DESCRIPTION
We need to check if tx is legacy in `CallMsgFromTx()` otherwise [GasFeeCap() from go-ethereum](https://github.com/ethereum/go-ethereum/blob/master/core/types/transaction.go#L298) will return non nil value which causes `both gasPrice and (maxFeePerGas or maxPriorityFeePerGas) specified` error.