### PR TITLE
Automation lessons learnt

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,15 +127,20 @@ Setup your BIN directory (relative to `seth.toml`)
 bin_dir = "contracts/bin"
 ```
 
-You can enable auto-tracing for all transactions, which means that every time you use `Decode()` we will not only decode the transaction but also trace all calls made within the transaction, together with all inputs, outputs, logs and events
+You can enable auto-tracing for all transactions meeting configured level, which means that every time you use `Decode()` we will decode the transaction and also trace all calls made within the transaction, together with all inputs, outputs, logs and events. Three tracing levels are available:
+* `all` - trace all transactions
+* `reverted` - trace only reverted transactions (that's default setting used if you don't set `tracing_level`)
+* `none` - don't trace any transactions
+Example:
 ```
-tracing_enabled = true
+tracing_level = "reverted"
 ```
 
-Additionally you can also enable saving all tracing information to JSON files with:
+Additionally you can also enable saving all decoding/tracing information to JSON files with:
 ```
 trace_to_json = true
 ```
+That option should be used with care, when `tracing_level` is set to `all` as it will generate a lot of data.
 
 You can add more networks like this:
 ```
@@ -154,14 +159,10 @@ eip_1559_dynamic_fees = true
 gas_fee_cap = 25_000_000_000
 gas_tip_cap = 1_800_000_000
 urls_secret = ["..."]
-# if set to true we will check if address has a pending nonce (transaction) and panic if it does
-pending_nonce_protection_enabled = false
 # if set to true we will dynamically estimate gas for every transaction (explained in more detail below)
 gas_estimation_enabled = true
 # how many last blocks to use, when estimating gas for a transaction
 gas_estimation_blocks = 1000
-# maximum price we are willing to pay for a transaction (will be used to calculate gas price or tip/fee cap according to gas limit)
-gas_estimation_max_tx_cost_wei = 10_000_000_000
 # priority of the transaction, can be "fast", "standard" or "slow" (the higher the priority, the higher adjustment factor and buffer will be used for gas estimation) [default: "standard"]
 gas_estimation_tx_priority = "slow"
 ```
@@ -328,7 +329,7 @@ For both transaction types if any of the steps fails, we fallback to hardcoded v
 In order to enable an experimental feature you need to pass it's name in config. It's a global config, you cannot enable it per-network. Example:
 ```toml
 # other settings before...
-tracing_enabled = false
+tracing_level = "reverted"
 trace_to_json = false
 experiments_enabled = ["slow_funds_return", "eip_1559_fee_equalizer"]
 ```

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ chain_id = "43113"
 transaction_timeout = "30s"
 # gas limit should be explicitly set only if you are connecting to a node that's incapable of estimating gas limit itself (should only happen for very old versions)
 # gas_limit = 9_000_000
-# gas limit for sending funds
+# hardcoded gas limit for sending funds that will be used if estimation of gas limit fails
 transfer_gas_fee = 21_000
 # legacy transactions
 gas_price = 1_000_000_000

--- a/README.md
+++ b/README.md
@@ -113,9 +113,10 @@ export ROOT_PRIVATE_KEY=ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7b
 alias seth="go run cmd/seth/seth.go" # useful alias for keyfile CLI
 ```
 
-If `SETH_KEYFILE_PATH` is not set then client will create 60 ephemeral keys and won't return any funds
+If `SETH_KEYFILE_PATH` is not set then client will create X ephemeral keys (60 by default, configurable) and won't return any funds.
 
-Use `SETH_KEYFILE_PATH` for testnets/mainnets and `ephemeral` mode only when testing against simulated network
+Use `SETH_KEYFILE_PATH` for testnets/mainnets and `ephemeral` mode only when testing against simulated network.
+
 ### seth.toml
 Set up your ABI directory (relative to `seth.toml`)
 ```
@@ -125,6 +126,11 @@ abi_dir = "contracts/abi"
 Setup your BIN directory (relative to `seth.toml`)
 ```
 bin_dir = "contracts/bin"
+```
+
+Set number of ephemeral keys to be generated (0 for no ephemeral keys). Each key will receive a proportion of native tokens from root private key's balance with the value equal to `(root_balance / ephemeral_keys_number) - transfer_fee * ephemeral_keys_number`. Using ephemeral keys together with keyfile will result in an error.
+```
+ephemeral_addresses_number = 0
 ```
 
 You can enable auto-tracing for all transactions meeting configured level, which means that every time you use `Decode()` we will decode the transaction and also trace all calls made within the transaction, together with all inputs, outputs, logs and events. Three tracing levels are available:

--- a/client.go
+++ b/client.go
@@ -747,13 +747,7 @@ func (m *Client) getProposedTransactionOptions(keyNum int) (*bind.TransactOpts, 
 			Msg("Pending nonce protection is enabled. Nonce status is OK")
 	}
 
-	estimations := m.CalculateGasEstimations(GasEstimationRequest{
-		GasEstimationEnabled: m.Cfg.Network.GasPriceEstimationEnabled,
-		FallbackGasPrice:     m.Cfg.Network.GasPrice,
-		FallbackGasFeeCap:    m.Cfg.Network.GasFeeCap,
-		FallbackGasTipCap:    m.Cfg.Network.GasTipCap,
-		Priority:             m.Cfg.Network.GasPriceEstimationTxPriority,
-	})
+	estimations := m.CalculateGasEstimations(m.NewDefaultGasEstimationRequest())
 
 	L.Debug().
 		Interface("KeyNum", keyNum).
@@ -775,6 +769,17 @@ type GasEstimationRequest struct {
 	FallbackGasFeeCap    int64
 	FallbackGasTipCap    int64
 	Priority             string
+}
+
+// NewDefaultGasEstimationRequest creates a new default gas estimation request based on current network configuration
+func (m *Client) NewDefaultGasEstimationRequest() GasEstimationRequest {
+	return GasEstimationRequest{
+		GasEstimationEnabled: m.Cfg.Network.GasPriceEstimationEnabled,
+		FallbackGasPrice:     m.Cfg.Network.GasPrice,
+		FallbackGasFeeCap:    m.Cfg.Network.GasFeeCap,
+		FallbackGasTipCap:    m.Cfg.Network.GasTipCap,
+		Priority:             m.Cfg.Network.GasPriceEstimationTxPriority,
+	}
 }
 
 // CalculateGasEstimations calculates gas estimations (price, tip/cap) or uses hardcoded values if estimation is disabled,

--- a/client.go
+++ b/client.go
@@ -41,6 +41,8 @@ var (
 	// Number of ephemeral addresses to create
 	SixtyEphemeralAddresses int64 = 60
 
+	ZeroBigInt = big.NewInt(0)
+
 	// Amount of funds that will be left on the root key, when splitting funds between ephemeral addresses
 	ZeroRootKeyFundsBuffer = big.NewInt(0)
 
@@ -180,10 +182,6 @@ func validateConfig(cfg *Config) error {
 	case TracingLevel_All:
 	default:
 		return errors.New("tracing level must be one of: NONE, REVERTED, ALL")
-	}
-
-	if big.NewInt(0).Cmp(cfg.EphemeralAddrsFunding) > 0 {
-		return errors.New("funding for ephemeral addresses must be greater than 0")
 	}
 
 	return nil

--- a/client.go
+++ b/client.go
@@ -224,6 +224,10 @@ func NewClientRaw(
 		o(c)
 	}
 
+	if err := readKeyFileConfig(cfg); err != nil {
+		return nil, err
+	}
+
 	if c.ContractAddressToNameMap.addressMap == nil {
 		c.ContractAddressToNameMap = NewEmptyContractMap()
 		if !cfg.IsSimulatedNetwork() {

--- a/client.go
+++ b/client.go
@@ -98,6 +98,10 @@ func NewClientWithConfig(cfg *Config) (*Client, error) {
 			return nil, err
 		}
 		cfg.Network.PrivateKeys = append(cfg.Network.PrivateKeys, pkeys...)
+	} else {
+		if err := readKeyFileConfig(cfg); err != nil {
+			return nil, err
+		}
 	}
 	addrs, pkeys, err := cfg.ParseKeys()
 	if err != nil {
@@ -224,10 +228,6 @@ func NewClientRaw(
 	}
 	for _, o := range opts {
 		o(c)
-	}
-
-	if err := readKeyFileConfig(cfg); err != nil {
-		return nil, err
 	}
 
 	if c.ContractAddressToNameMap.addressMap == nil {

--- a/client.go
+++ b/client.go
@@ -982,6 +982,12 @@ func (m *Client) DeployContract(auth *bind.TransactOpts, name string, abi abi.AB
 	L.Info().
 		Msgf("Started deploying %s contract", name)
 
+	if auth.Context != nil {
+		if err, ok := auth.Context.Value(ContextErrorKey{}).(error); ok {
+			return DeploymentData{}, errors.Wrapf(err, "aborted contract deployment for %s, because context passed in transaction options had an error set", name)
+		}
+	}
+
 	address, tx, contract, err := bind.DeployContract(auth, abi, bytecode, m.Client, params...)
 	if err != nil {
 		return DeploymentData{}, wrapErrInMessageWithASuggestion(err)

--- a/client.go
+++ b/client.go
@@ -355,7 +355,7 @@ func (m *Client) Decode(tx *types.Transaction, txErr error) (*DecodedTransaction
 	if m.Cfg.TracingLevel == TracingLevel_All || (m.Cfg.TracingLevel == TracingLevel_Reverted && revertErr != nil) {
 		var decodeErr error
 		decoded, decodeErr = m.decodeTransaction(l, tx, receipt)
-		if decodeErr != nil {
+		if decodeErr != nil && errors.Is(decodeErr, errors.New(ErrNoABIMethod)) {
 			if m.Cfg.TraceToJson {
 				L.Debug().
 					Err(decodeErr).

--- a/client.go
+++ b/client.go
@@ -689,7 +689,10 @@ func (m *Client) NewTXOpts(o ...TransactOpt) *bind.TransactOpts {
 // sets opts.GasPrice and opts.GasLimit from seth.toml or override with options
 func (m *Client) NewTXKeyOpts(keyNum int, o ...TransactOpt) *bind.TransactOpts {
 	if keyNum > len(m.Addresses) || keyNum < 0 {
-		panic(fmt.Errorf("keyNum is out of range. Expected %d-%d. Got: %d", 0, len(m.Addresses)-1, keyNum))
+		err := fmt.Errorf("keyNum is out of range. Expected %d-%d. Got: %d", 0, len(m.Addresses)-1, keyNum)
+		m.Errors = append(m.Errors, err)
+		// can't return nil, otherwise RPC wrapper will panic and we will lose funds on testnets/mainnets
+		return &bind.TransactOpts{}
 	}
 	L.Debug().
 		Interface("KeyNum", keyNum).

--- a/client.go
+++ b/client.go
@@ -839,7 +839,7 @@ func (m *Client) DeployContract(auth *bind.TransactOpts, name string, abi abi.AB
 
 	address, tx, contract, err := bind.DeployContract(auth, abi, bytecode, m.Client, params...)
 	if err != nil {
-		return DeploymentData{}, err
+		return DeploymentData{}, wrapErrInMessageWithASuggestion(err)
 	}
 
 	L.Info().
@@ -865,7 +865,7 @@ func (m *Client) DeployContract(auth *bind.TransactOpts, name string, abi abi.AB
 				strings.Contains(strings.ToLower(err.Error()), "no contract code after deployment")
 		}),
 	); err != nil {
-		return DeploymentData{}, err
+		return DeploymentData{}, wrapErrInMessageWithASuggestion(err)
 	}
 
 	L.Info().

--- a/client.go
+++ b/client.go
@@ -85,6 +85,12 @@ func NewClientWithConfig(cfg *Config) (*Client, error) {
 		return nil, errors.Wrap(err, ErrCreateABIStore)
 	}
 	if cfg.ephemeral {
+		// we don't care about any other keys, only the root key
+		// you should not use ephemeral mode with more than 1 key
+		if len(cfg.Network.PrivateKeys) > 1 {
+			L.Warn().Msg("Ephemeral mode is enabled, but more than 1 key is loaded. Only the first key will be used")
+		}
+		cfg.Network.PrivateKeys = cfg.Network.PrivateKeys[:1]
 		pkeys, err := NewEphemeralKeys(*cfg.EphemeralAddrs)
 		if err != nil {
 			return nil, err

--- a/client.go
+++ b/client.go
@@ -401,14 +401,14 @@ func (m *Client) decodeInternal(tx *types.Transaction, txErr error, ignoreTraceL
 		Hash:        tx.Hash().Hex(),
 	}
 
-	if m.Cfg.TracingLevel == TracingLevel_None && !ignoreTraceLevel {
+	if !ignoreTraceLevel && (m.Cfg.TracingLevel == TracingLevel_None) {
 		L.Trace().
 			Str("Transaction Hash", tx.Hash().Hex()).
 			Msg("Tracing level is NONE, skipping decoding")
 		return decoded, revertErr
 	}
 
-	if !ignoreTraceLevel && m.Cfg.TracingLevel == TracingLevel_All || (m.Cfg.TracingLevel == TracingLevel_Reverted && revertErr != nil) {
+	if ignoreTraceLevel || (m.Cfg.TracingLevel == TracingLevel_All || (m.Cfg.TracingLevel == TracingLevel_Reverted && revertErr != nil)) {
 		var decodeErr error
 		decoded, decodeErr = m.decodeTransaction(l, tx, receipt)
 		if decodeErr != nil && errors.Is(decodeErr, errors.New(ErrNoABIMethod)) {

--- a/client.go
+++ b/client.go
@@ -703,6 +703,8 @@ func WithGasTipCap(gasTipCap *big.Int) TransactOpt {
 	}
 }
 
+type ContextErrorKey struct{}
+
 type ContextErrorValue struct {
 	Error           error
 	ContextCancelFn context.CancelFunc
@@ -742,7 +744,7 @@ func (m *Client) NewTXKeyOpts(keyNum int, o ...TransactOpt) *bind.TransactOpts {
 		// error is passed here to avoid panic, whoever is using Seth should make sure that there is no error
 		// before using *bind.TransactOpts
 		deadlineCtx, cancelFn := context.WithTimeout(context.Background(), m.Cfg.Network.TxnTimeout.Duration())
-		ctx := context.WithValue(deadlineCtx, "error", ContextErrorValue{Error: err, ContextCancelFn: cancelFn})
+		ctx := context.WithValue(deadlineCtx, ContextErrorKey{}, ContextErrorValue{Error: err, ContextCancelFn: cancelFn})
 
 		opts.Context = ctx
 
@@ -810,7 +812,7 @@ func (m *Client) getProposedTransactionOptions(keyNum int) (*bind.TransactOpts, 
 		m.Errors = append(m.Errors, err)
 		// can't return nil, otherwise RPC wrapper will panic
 		deadlineCtx, cancelFn := context.WithTimeout(context.Background(), m.Cfg.Network.TxnTimeout.Duration())
-		ctx := context.WithValue(deadlineCtx, "error", ContextErrorValue{Error: err, ContextCancelFn: cancelFn})
+		ctx := context.WithValue(deadlineCtx, ContextErrorKey{}, ContextErrorValue{Error: err, ContextCancelFn: cancelFn})
 
 		return &bind.TransactOpts{Context: ctx}, NonceStatus{}, GasEstimations{}
 	}

--- a/client_api_test.go
+++ b/client_api_test.go
@@ -21,7 +21,7 @@ func TestAPI(t *testing.T) {
 	c := newClientWithEphemeralAddresses(t)
 
 	t.Cleanup(func() {
-		seth.ReturnFunds(c, c.Addresses[0].Hex())
+		_ = seth.ReturnFunds(c, c.Addresses[0].Hex())
 	})
 
 	type test struct {
@@ -104,7 +104,7 @@ func TestAPINonces(t *testing.T) {
 	c := newClientWithEphemeralAddresses(t)
 
 	t.Cleanup(func() {
-		seth.ReturnFunds(c, c.Addresses[0].Hex())
+		_ = seth.ReturnFunds(c, c.Addresses[0].Hex())
 	})
 
 	type test struct {
@@ -144,7 +144,7 @@ func TestAPISeqErrors(t *testing.T) {
 	c := newClientWithEphemeralAddresses(t)
 
 	t.Cleanup(func() {
-		seth.ReturnFunds(c, c.Addresses[0].Hex())
+		_ = seth.ReturnFunds(c, c.Addresses[0].Hex())
 	})
 
 	type test struct {
@@ -303,7 +303,7 @@ func TestAPISyncKeysPool(t *testing.T) {
 				c = newClientWithEphemeralAddresses(t)
 
 				t.Cleanup(func() {
-					seth.ReturnFunds(c, c.Addresses[0].Hex())
+					_ = seth.ReturnFunds(c, c.Addresses[0].Hex())
 				})
 			} else {
 				c = newClient(t)
@@ -350,7 +350,7 @@ func TestManualAPIReconnect(t *testing.T) {
 	c := newClientWithEphemeralAddresses(t)
 
 	t.Cleanup(func() {
-		seth.ReturnFunds(c, c.Addresses[0].Hex())
+		_ = seth.ReturnFunds(c, c.Addresses[0].Hex())
 	})
 
 	type test struct {

--- a/client_api_test.go
+++ b/client_api_test.go
@@ -18,6 +18,7 @@ import (
 
 func TestAPI(t *testing.T) {
 	c := newClientWithEphemeralAddresses(t)
+	c.Cfg.TracingLevel = seth.TracingLevel_All
 
 	type test struct {
 		name            string

--- a/client_api_test.go
+++ b/client_api_test.go
@@ -293,9 +293,16 @@ func TestAPISyncKeysPool(t *testing.T) {
 					wg.Add(1)
 					go func() {
 						defer wg.Done()
-						_, err := c.Decode(
-							TestEnv.DebugContract.AddCounter(c.NewTXKeyOpts(c.AnySyncedKey()), big.NewInt(tc.counterIdx), big.NewInt(1)),
-						)
+						keyNum := c.AnySyncedKey()
+						var err error
+						if keyNum == -1 {
+							err = errors.New("-1 keyNum was returned, which means there was a syncing timeout")
+						} else {
+							_, err = c.Decode(
+								TestEnv.DebugContract.AddCounter(c.NewTXKeyOpts(keyNum), big.NewInt(tc.counterIdx), big.NewInt(1)),
+							)
+						}
+
 						if tc.shouldFail {
 							require.Error(t, err)
 							return

--- a/client_contract_map_test.go
+++ b/client_contract_map_test.go
@@ -70,15 +70,15 @@ func TestContractMapNonSimulatedClientSavesAndReadsContractMap(t *testing.T) {
 	cfg := client.Cfg
 	newNonSimulatedClient, err := seth.NewClientRaw(cfg, client.Addresses, client.PrivateKeys)
 	require.NoError(t, err, "failed to create new client")
-	require.Equal(t, 1, len(newNonSimulatedClient.ContractAddressToNameMap), "expected contract map to be saved")
+	require.Equal(t, 1, newNonSimulatedClient.ContractAddressToNameMap.Size(), "expected contract map to be saved")
 
-	expectedMap := seth.ContractMap{data.Address.Hex(): "NetworkDebugSubContract"}
+	expectedMap := seth.NewContractMap(map[string]string{data.Address.Hex(): "NetworkDebugSubContract"})
 	require.Equal(t, expectedMap, newNonSimulatedClient.ContractAddressToNameMap, "expected contract map to be saved")
 
 	cfg.Network.Name = seth.GETH
 	newSimulatedClient, err := seth.NewClientRaw(cfg, client.Addresses, client.PrivateKeys)
 	require.NoError(t, err, "failed to create new client")
-	require.Equal(t, 0, len(newSimulatedClient.ContractAddressToNameMap), "expected contract map to be saved")
+	require.Equal(t, 0, newSimulatedClient.ContractAddressToNameMap.Size(), "expected contract map to be saved")
 }
 
 func TestContractMapSimulatedClientDoesntSaveContractMap(t *testing.T) {
@@ -108,7 +108,7 @@ func TestContractMapNewClientIsCreatedEvenIfNoContractMapFileExists(t *testing.T
 
 	newClient, err := seth.NewClientRaw(cfg, TestEnv.Client.Addresses, TestEnv.Client.PrivateKeys, seth.WithNonceManager(nm), seth.WithContractStore(TestEnv.Client.ContractStore))
 	require.NoError(t, err, "failed to create new client")
-	require.Equal(t, 0, len(newClient.ContractAddressToNameMap), "expected contract map to be saved")
+	require.Equal(t, 0, newClient.ContractAddressToNameMap.Size(), "expected contract map to be saved")
 
 	_, err = newClient.DeployContractFromContractStore(newClient.NewTXOpts(), "NetworkDebugSubContract")
 	require.NoError(t, err, "failed to deploy contract")
@@ -118,12 +118,12 @@ func TestContractMapNewClientIsCreatedEvenIfNoContractMapFileExists(t *testing.T
 	})
 
 	// make sure deployed contract is present in the contract map
-	require.Equal(t, 1, len(newClient.ContractAddressToNameMap), "expected contract map to be saved")
+	require.Equal(t, 1, newClient.ContractAddressToNameMap.Size(), "expected contract map to be saved")
 
 	// make sure that new client instance loads map from existing file instead of creating a new one
 	newClient, err = seth.NewClientRaw(cfg, TestEnv.Client.Addresses, TestEnv.Client.PrivateKeys, seth.WithNonceManager(nm), seth.WithContractStore(TestEnv.Client.ContractStore))
 	require.NoError(t, err, "failed to create new client")
-	require.Equal(t, 1, len(newClient.ContractAddressToNameMap), "expected contract map to be saved")
+	require.Equal(t, 1, newClient.ContractAddressToNameMap.Size(), "expected contract map to be saved")
 }
 
 func TestContractMapNewClientIsNotCreatedWhenCorruptedContractMapFileExists(t *testing.T) {

--- a/client_decode_test.go
+++ b/client_decode_test.go
@@ -63,6 +63,7 @@ func TestSmokeDebugReverts(t *testing.T) {
 
 func TestSmokeDebugData(t *testing.T) {
 	c := newClient(t)
+	c.Cfg.TracingLevel = seth.TracingLevel_All
 
 	type test struct {
 		name   string

--- a/client_main_test.go
+++ b/client_main_test.go
@@ -38,7 +38,7 @@ type TestEnvironment struct {
 	DebugContractAddress    common.Address
 	DebugSubContractAddress common.Address
 	DebugContractRaw        *bind.BoundContract
-	ContractMap             map[string]string
+	ContractMap             seth.ContractMap
 }
 
 func newClient(t *testing.T) *seth.Client {
@@ -78,15 +78,15 @@ func TestDeploymentLinkTokenFromGethWrapperExample(t *testing.T) {
 
 func newClientWithContractMapFromEnv(t *testing.T) *seth.Client {
 	c := newClient(t)
-	if len(TestEnv.ContractMap) == 0 {
+	if TestEnv.ContractMap.Size() == 0 {
 		t.Fatal("contract map is empty")
 	}
 
 	// create a copy of the map, so we don't have problem with side effects of modyfing client's map
 	// impacting the global, underlaying one
-	contractMap := make(map[string]string)
-	for k, v := range TestEnv.ContractMap {
-		contractMap[k] = v
+	contractMap := seth.NewEmptyContractMap()
+	for k, v := range TestEnv.ContractMap.GetContractMap() {
+		contractMap.AddContract(k, v)
 	}
 
 	c.ContractAddressToNameMap = contractMap
@@ -121,7 +121,7 @@ func NewDebugContractSetup() (
 	if err != nil {
 		return nil, nil, common.Address{}, common.Address{}, nil, err
 	}
-	contractMap := make(map[string]string)
+	contractMap := seth.NewEmptyContractMap()
 
 	abiFinder := seth.NewABIFinder(contractMap, cs)
 	tracer, err := seth.NewTracer(cfg.Network.URLs[0], cs, &abiFinder, cfg, contractMap, addrs)
@@ -155,9 +155,9 @@ func TestMain(m *testing.M) {
 		panic(err)
 	}
 
-	contractMap := make(map[string]string)
-	for k, v := range client.ContractAddressToNameMap {
-		contractMap[k] = v
+	contractMap := seth.NewEmptyContractMap()
+	for k, v := range client.ContractAddressToNameMap.GetContractMap() {
+		contractMap.AddContract(k, v)
 	}
 
 	TestEnv = TestEnvironment{

--- a/client_trace_test.go
+++ b/client_trace_test.go
@@ -1355,7 +1355,7 @@ func TestTraceTraceContractTracingSaveToJson(t *testing.T) {
 
 	// when this level is set we don't need to call TraceGethTX, because it's called automatically
 	cfg.TracingLevel = seth.TracingLevel_All
-	cfg.TraceToJson = true
+	cfg.SaveToJson = true
 	cfg.Network.TxnTimeout = seth.MustMakeDuration(time.Duration(5 * time.Second))
 
 	c, err := seth.NewClientRaw(

--- a/client_trace_test.go
+++ b/client_trace_test.go
@@ -1355,7 +1355,7 @@ func TestTraceTraceContractTracingSaveToJson(t *testing.T) {
 
 	// when this level is set we don't need to call TraceGethTX, because it's called automatically
 	cfg.TracingLevel = seth.TracingLevel_All
-	cfg.SaveToJson = true
+	cfg.TraceToJson = true
 	cfg.Network.TxnTimeout = seth.MustMakeDuration(time.Duration(5 * time.Second))
 
 	c, err := seth.NewClientRaw(

--- a/client_trace_test.go
+++ b/client_trace_test.go
@@ -39,8 +39,8 @@ func TestTraceTraceContractTracingSameMethodSignatures_UploadedViaSeth(t *testin
 	c := newClientWithContractMapFromEnv(t)
 	SkipAnvil(t, c)
 
-	// when this flag is enabled we don't need to call TraceGethTX, because it's called automatically
-	c.Cfg.TracingEnabled = true
+	// when this level is set we don't need to call TraceGethTX, because it's called automatically
+	c.Cfg.TracingLevel = seth.TracingLevel_All
 
 	var x int64 = 2
 	var y int64 = 4
@@ -128,12 +128,12 @@ func TestTraceTraceContractTracingSameMethodSignatures_UploadedManually(t *testi
 	c := newClient(t)
 	SkipAnvil(t, c)
 
-	for k := range c.ContractAddressToNameMap {
-		delete(c.ContractAddressToNameMap, k)
+	for k := range c.ContractAddressToNameMap.GetContractMap() {
+		delete(c.ContractAddressToNameMap.GetContractMap(), k)
 	}
 
-	// when this flag is enabled we don't need to call TraceGethTX, because it's called automatically
-	c.Cfg.TracingEnabled = true
+	// when this level is set we don't need to call TraceGethTX, because it's called automatically
+	c.Cfg.TracingLevel = seth.TracingLevel_All
 
 	// let's simulate this case, because it doesn't happen always, it all depends on the order of the
 	// contract map, which is non-deterministic (hash map with keys being dynamically generated addresses)
@@ -270,10 +270,10 @@ func TestTraceTraceContractTracingSameMethodSignaturesWarningInComment_UploadedM
 	c := newClient(t)
 	SkipAnvil(t, c)
 
-	c.ContractAddressToNameMap = make(map[string]string)
+	c.ContractAddressToNameMap = seth.NewEmptyContractMap()
 
-	// when this flag is enabled we don't need to call TraceGethTX, because it's called automatically
-	c.Cfg.TracingEnabled = true
+	// when this level is set we don't need to call TraceGethTX, because it's called automatically
+	c.Cfg.TracingLevel = seth.TracingLevel_All
 
 	sameSigTx, err := c.Decode(TestEnv.DebugContract.Trace(c.NewTXOpts(), big.NewInt(2), big.NewInt(2)))
 	require.NoError(t, err, "failed to send transaction")
@@ -289,8 +289,8 @@ func TestTraceTraceContractTracingWithCallback_UploadedViaSeth(t *testing.T) {
 	c := newClientWithContractMapFromEnv(t)
 	SkipAnvil(t, c)
 
-	// when this flag is enabled we don't need to call TraceGethTX, because it's called automatically
-	c.Cfg.TracingEnabled = true
+	// when this level is set we don't need to call TraceGethTX, because it's called automatically
+	c.Cfg.TracingLevel = seth.TracingLevel_All
 
 	// As this test might fail if run multiple times due to undterministic addressed in contract mapping
 	// which sometime causes the call to be traced and sometimes not (it all depends on the order of
@@ -414,11 +414,11 @@ func TestTraceTraceContractTracingUnknownAbi(t *testing.T) {
 	c := newClientWithContractMapFromEnv(t)
 	SkipAnvil(t, c)
 
-	// when this flag is enabled we don't need to call TraceGethTX, because it's called automatically
-	c.Cfg.TracingEnabled = true
+	// when this level is set we don't need to call TraceGethTX, because it's called automatically
+	c.Cfg.TracingLevel = seth.TracingLevel_All
 
 	// simulate missing ABI
-	delete(c.ContractAddressToNameMap, strings.ToLower(TestEnv.DebugContractAddress.Hex()))
+	delete(c.ContractAddressToNameMap.GetContractMap(), strings.ToLower(TestEnv.DebugContractAddress.Hex()))
 	delete(c.ContractStore.ABIs, "NetworkDebugContract.abi")
 
 	var x int64 = 2
@@ -471,8 +471,8 @@ func TestTraceTraceContractTracingNamedInputsAndOutputs(t *testing.T) {
 	c := newClientWithContractMapFromEnv(t)
 	SkipAnvil(t, c)
 
-	// when this flag is enabled we don't need to call TraceGethTX, because it's called automatically
-	c.Cfg.TracingEnabled = true
+	// when this level is set we don't need to call TraceGethTX, because it's called automatically
+	c.Cfg.TracingLevel = seth.TracingLevel_All
 
 	x := big.NewInt(1000)
 	var testString = "string"
@@ -504,8 +504,8 @@ func TestTraceTraceContractTracingNamedInputsAnonymousOutputs(t *testing.T) {
 	c := newClientWithContractMapFromEnv(t)
 	SkipAnvil(t, c)
 
-	// when this flag is enabled we don't need to call TraceGethTX, because it's called automatically
-	c.Cfg.TracingEnabled = true
+	// when this level is set we don't need to call TraceGethTX, because it's called automatically
+	c.Cfg.TracingLevel = seth.TracingLevel_All
 
 	x := big.NewInt(1001)
 	var testString = "string"
@@ -538,8 +538,8 @@ func TestTraceTraceContractTracingIntInputsWithoutLength(t *testing.T) {
 	c := newClientWithContractMapFromEnv(t)
 	SkipAnvil(t, c)
 
-	// when this flag is enabled we don't need to call TraceGethTX, because it's called automatically
-	c.Cfg.TracingEnabled = true
+	// when this level is set we don't need to call TraceGethTX, because it's called automatically
+	c.Cfg.TracingLevel = seth.TracingLevel_All
 
 	x := big.NewInt(1001)
 	y := big.NewInt(2)
@@ -571,8 +571,8 @@ func TestTraceTraceContractTracingAddressInputAndOutput(t *testing.T) {
 	c := newClientWithContractMapFromEnv(t)
 	SkipAnvil(t, c)
 
-	// when this flag is enabled we don't need to call TraceGethTX, because it's called automatically
-	c.Cfg.TracingEnabled = true
+	// when this level is set we don't need to call TraceGethTX, because it's called automatically
+	c.Cfg.TracingLevel = seth.TracingLevel_All
 
 	address := c.Addresses[0]
 	tx, txErr := c.Decode(TestEnv.DebugContract.EmitAddress(c.NewTXOpts(), address))
@@ -603,8 +603,8 @@ func TestTraceTraceContractTracingBytes32InputAndOutput(t *testing.T) {
 	c := newClientWithContractMapFromEnv(t)
 	SkipAnvil(t, c)
 
-	// when this flag is enabled we don't need to call TraceGethTX, because it's called automatically
-	c.Cfg.TracingEnabled = true
+	// when this level is set we don't need to call TraceGethTX, because it's called automatically
+	c.Cfg.TracingLevel = seth.TracingLevel_All
 
 	addrAsBytes := c.Addresses[0].Bytes()
 	addrAsBytes = append(addrAsBytes, c.Addresses[0].Bytes()...)
@@ -637,8 +637,8 @@ func TestTraceTraceContractTracingUint256ArrayInputAndOutput(t *testing.T) {
 	c := newClientWithContractMapFromEnv(t)
 	SkipAnvil(t, c)
 
-	// when this flag is enabled we don't need to call TraceGethTX, because it's called automatically
-	c.Cfg.TracingEnabled = true
+	// when this level is set we don't need to call TraceGethTX, because it's called automatically
+	c.Cfg.TracingLevel = seth.TracingLevel_All
 
 	uint256Array := []*big.Int{big.NewInt(1), big.NewInt(19271), big.NewInt(261), big.NewInt(271911), big.NewInt(821762721)}
 	tx, txErr := c.Decode(TestEnv.DebugContract.ProcessUintArray(c.NewTXOpts(), uint256Array))
@@ -673,8 +673,8 @@ func TestTraceTraceContractTracingAddressArrayInputAndOutput(t *testing.T) {
 	c := newClientWithContractMapFromEnv(t)
 	SkipAnvil(t, c)
 
-	// when this flag is enabled we don't need to call TraceGethTX, because it's called automatically
-	c.Cfg.TracingEnabled = true
+	// when this level is set we don't need to call TraceGethTX, because it's called automatically
+	c.Cfg.TracingLevel = seth.TracingLevel_All
 
 	addressArray := []common.Address{c.Addresses[0], TestEnv.DebugSubContractAddress}
 	tx, txErr := c.Decode(TestEnv.DebugContract.ProcessAddressArray(c.NewTXOpts(), addressArray))
@@ -704,8 +704,8 @@ func TestTraceTraceContractTracingStructWithDynamicFieldsInputAndOutput(t *testi
 	c := newClientWithContractMapFromEnv(t)
 	SkipAnvil(t, c)
 
-	// when this flag is enabled we don't need to call TraceGethTX, because it's called automatically
-	c.Cfg.TracingEnabled = true
+	// when this level is set we don't need to call TraceGethTX, because it's called automatically
+	c.Cfg.TracingLevel = seth.TracingLevel_All
 
 	data := network_debug_contract.NetworkDebugContractData{
 		Name:   "my awesome name",
@@ -746,8 +746,8 @@ func TestTraceTraceContractTracingStructArrayWithDynamicFieldsInputAndOutput(t *
 	c := newClientWithContractMapFromEnv(t)
 	SkipAnvil(t, c)
 
-	// when this flag is enabled we don't need to call TraceGethTX, because it's called automatically
-	c.Cfg.TracingEnabled = true
+	// when this level is set we don't need to call TraceGethTX, because it's called automatically
+	c.Cfg.TracingLevel = seth.TracingLevel_All
 
 	data := network_debug_contract.NetworkDebugContractData{
 		Name:   "my awesome name",
@@ -813,8 +813,8 @@ func TestTraceTraceContractTracingNestedStructsWithDynamicFieldsInputAndOutput(t
 	c := newClientWithContractMapFromEnv(t)
 	SkipAnvil(t, c)
 
-	// when this flag is enabled we don't need to call TraceGethTX, because it's called automatically
-	c.Cfg.TracingEnabled = true
+	// when this level is set we don't need to call TraceGethTX, because it's called automatically
+	c.Cfg.TracingLevel = seth.TracingLevel_All
 
 	data := network_debug_contract.NetworkDebugContractNestedData{
 		Data: network_debug_contract.NetworkDebugContractData{
@@ -867,8 +867,8 @@ func TestTraceTraceContractTracingNestedStructsWithDynamicFieldsInputAndStructOu
 	c := newClientWithContractMapFromEnv(t)
 	SkipAnvil(t, c)
 
-	// when this flag is enabled we don't need to call TraceGethTX, because it's called automatically
-	c.Cfg.TracingEnabled = true
+	// when this level is set we don't need to call TraceGethTX, because it's called automatically
+	c.Cfg.TracingLevel = seth.TracingLevel_All
 
 	data := network_debug_contract.NetworkDebugContractData{
 		Name:   "my awesome name",
@@ -928,8 +928,8 @@ func TestTraceTraceContractTracingPayable(t *testing.T) {
 	c := newClientWithContractMapFromEnv(t)
 	SkipAnvil(t, c)
 
-	// when this flag is enabled we don't need to call TraceGethTX, because it's called automatically
-	c.Cfg.TracingEnabled = true
+	// when this level is set we don't need to call TraceGethTX, because it's called automatically
+	c.Cfg.TracingLevel = seth.TracingLevel_All
 
 	var value int64 = 1000
 	tx, txErr := c.Decode(TestEnv.DebugContract.Pay(c.NewTXOpts(seth.WithValue(big.NewInt(value)))))
@@ -961,8 +961,8 @@ func TestTraceTraceContractTracingFallback(t *testing.T) {
 	c := newClientWithContractMapFromEnv(t)
 	SkipAnvil(t, c)
 
-	// when this flag is enabled we don't need to call TraceGethTX, because it's called automatically
-	c.Cfg.TracingEnabled = true
+	// when this level is set we don't need to call TraceGethTX, because it's called automatically
+	c.Cfg.TracingLevel = seth.TracingLevel_All
 
 	tx, txErr := c.Decode(TestEnv.DebugContractRaw.RawTransact(c.NewTXOpts(), []byte("iDontExist")))
 	require.NoError(t, txErr, FailedToDecode)
@@ -991,8 +991,8 @@ func TestTraceTraceContractTracingReceive(t *testing.T) {
 	c := newClientWithContractMapFromEnv(t)
 	SkipAnvil(t, c)
 
-	// when this flag is enabled we don't need to call TraceGethTX, because it's called automatically
-	c.Cfg.TracingEnabled = true
+	// when this level is set we don't need to call TraceGethTX, because it's called automatically
+	c.Cfg.TracingLevel = seth.TracingLevel_All
 
 	value := big.NewInt(29121)
 	tx, txErr := c.Decode(TestEnv.DebugContract.Receive(c.NewTXOpts(seth.WithValue(value))))
@@ -1021,8 +1021,8 @@ func TestTraceTraceContractTracingEnumInputAndOutput(t *testing.T) {
 	c := newClientWithContractMapFromEnv(t)
 	SkipAnvil(t, c)
 
-	// when this flag is enabled we don't need to call TraceGethTX, because it's called automatically
-	c.Cfg.TracingEnabled = true
+	// when this level is set we don't need to call TraceGethTX, because it's called automatically
+	c.Cfg.TracingLevel = seth.TracingLevel_All
 
 	var status uint8 = 1 // Active
 	tx, txErr := c.Decode(TestEnv.DebugContract.SetStatus(c.NewTXOpts(), status))
@@ -1063,8 +1063,8 @@ func TestTraceTraceContractTracingNonIndexedEventParameter(t *testing.T) {
 	c := newClientWithContractMapFromEnv(t)
 	SkipAnvil(t, c)
 
-	// when this flag is enabled we don't need to call TraceGethTX, because it's called automatically
-	c.Cfg.TracingEnabled = true
+	// when this level is set we don't need to call TraceGethTX, because it's called automatically
+	c.Cfg.TracingLevel = seth.TracingLevel_All
 
 	tx, txErr := c.Decode(TestEnv.DebugContract.EmitNoIndexEventString(c.NewTXOpts()))
 	require.NoError(t, txErr, "failed to send transaction")
@@ -1103,8 +1103,8 @@ func TestTraceTraceContractTracingEventThreeIndexedParameters(t *testing.T) {
 	c := newClientWithContractMapFromEnv(t)
 	SkipAnvil(t, c)
 
-	// when this flag is enabled we don't need to call TraceGethTX, because it's called automatically
-	c.Cfg.TracingEnabled = true
+	// when this level is set we don't need to call TraceGethTX, because it's called automatically
+	c.Cfg.TracingLevel = seth.TracingLevel_All
 
 	tx, txErr := c.Decode(TestEnv.DebugContract.EmitThreeIndexEvent(c.NewTXOpts()))
 	require.NoError(t, txErr, FailedToDecode)
@@ -1146,8 +1146,8 @@ func TestTraceTraceContractTracingEventFourMixedParameters(t *testing.T) {
 	c := newClientWithContractMapFromEnv(t)
 	SkipAnvil(t, c)
 
-	// when this flag is enabled we don't need to call TraceGethTX, because it's called automatically
-	c.Cfg.TracingEnabled = true
+	// when this level is set we don't need to call TraceGethTX, because it's called automatically
+	c.Cfg.TracingLevel = seth.TracingLevel_All
 
 	tx, txErr := c.Decode(TestEnv.DebugContract.EmitFourParamMixedEvent(c.NewTXOpts()))
 	require.NoError(t, txErr, FailedToDecode)
@@ -1185,19 +1185,24 @@ func TestTraceTraceContractTracingEventFourMixedParameters(t *testing.T) {
 	require.EqualValues(t, expectedCall, c.Tracer.DecodedCalls[tx.Hash][0], "decoded call does not match")
 }
 
-func TestTraceTraceContractTraceReverted(t *testing.T) {
+func TestTraceTraceContractTraceOnlyReverted(t *testing.T) {
 	c := newClientWithContractMapFromEnv(t)
 	SkipAnvil(t, c)
 
-	// when this flag is enabled we don't need to call TraceGethTX, because it's called automatically
-	c.Cfg.TracingEnabled = true
-	c.TraceReverted = true
+	// when this level is set we don't need to call TraceGethTX, because it's automatically executed for all reverted transactions
+	c.Cfg.TracingLevel = seth.TracingLevel_Reverted
 
-	tx, txErr := TestEnv.DebugContract.AlwaysRevertsCustomError(c.NewTXOpts())
-	require.NoError(t, txErr, "transaction should have reverted")
-	_, decodeErr := c.Decode(tx, txErr)
+	revertedTx, txErr := TestEnv.DebugContract.AlwaysRevertsCustomError(c.NewTXOpts())
+	require.NoError(t, txErr, "transaction sending should not fail")
+	_, decodeErr := c.Decode(revertedTx, txErr)
 	require.Error(t, decodeErr, "transaction should have reverted")
 	require.Equal(t, "error type: CustomErr, error values: [12 21]", decodeErr.Error(), "expected error message to contain the reverted error type and values")
+
+	okTx, txErr := TestEnv.DebugContract.AddCounter(c.NewTXOpts(), big.NewInt(1), big.NewInt(2))
+	require.NoError(t, txErr, "transaction should not have reverted")
+	_, decodeErr = c.Decode(okTx, txErr)
+	require.NoError(t, decodeErr, "transaction decoding should not err")
+
 	require.Equal(t, 1, len(c.Tracer.DecodedCalls), "expected 1 decoded transacton")
 
 	expectedCall := &seth.DecodedCall{
@@ -1214,7 +1219,7 @@ func TestTraceTraceContractTraceReverted(t *testing.T) {
 	}
 
 	removeGasDataFromDecodedCalls(c.Tracer.DecodedCalls)
-	require.EqualValues(t, expectedCall, c.Tracer.DecodedCalls[tx.Hash().Hex()][0], "decoded call does not match")
+	require.EqualValues(t, expectedCall, c.Tracer.DecodedCalls[revertedTx.Hash().Hex()][0], "decoded call does not match")
 }
 
 func TestTraceTraceContractTracingClientIntialisesTracerIfTracingIsEnabled(t *testing.T) {
@@ -1226,7 +1231,8 @@ func TestTraceTraceContractTracingClientIntialisesTracerIfTracingIsEnabled(t *te
 	nm, err := seth.NewNonceManager(cfg, TestEnv.Client.Addresses, TestEnv.Client.PrivateKeys)
 	require.NoError(t, err, "failed to create nonce manager")
 
-	cfg.TracingEnabled = true
+	// when this level is set we don't need to call TraceGethTX, because it's called automatically
+	cfg.TracingLevel = seth.TracingLevel_All
 	cfg.Network.TxnTimeout = seth.MustMakeDuration(time.Duration(5 * time.Second))
 
 	c, err := seth.NewClientRaw(
@@ -1274,7 +1280,8 @@ func TestTraceTraceContractTracingSaveToJson(t *testing.T) {
 	nm, err := seth.NewNonceManager(cfg, TestEnv.Client.Addresses, TestEnv.Client.PrivateKeys)
 	require.NoError(t, err, "failed to create nonce manager")
 
-	cfg.TracingEnabled = true
+	// when this level is set we don't need to call TraceGethTX, because it's called automatically
+	cfg.TracingLevel = seth.TracingLevel_All
 	cfg.TraceToJson = true
 	cfg.Network.TxnTimeout = seth.MustMakeDuration(time.Duration(5 * time.Second))
 

--- a/config.go
+++ b/config.go
@@ -29,9 +29,10 @@ const (
 
 type Config struct {
 	// ephemeral is internal option used only from code
-	ephemeral          bool
-	EphemeralAddrs     *int64   `toml:"ephemeral_addresses_number"`
-	RootKeyFundsBuffer *big.Int `toml:"root_key_funds_buffer"`
+	ephemeral             bool
+	EphemeralAddrs        *int64   `toml:"ephemeral_addresses_number"`
+	EphemeralAddrsFunding *big.Int `toml:"ephemeral_addresses_funding"`
+	RootKeyFundsBuffer    *big.Int `toml:"root_key_funds_buffer"`
 
 	ABIDir                        string `toml:"abi_dir"`
 	BINDir                        string `toml:"bin_dir"`

--- a/config.go
+++ b/config.go
@@ -3,6 +3,7 @@ package seth
 import (
 	"crypto/ecdsa"
 	"fmt"
+	"math/big"
 	"os"
 	"path/filepath"
 	"strings"
@@ -28,8 +29,9 @@ const (
 
 type Config struct {
 	// ephemeral is internal option used only from code
-	ephemeral      bool
-	EphemeralAddrs *int64 `toml:"ephemeral_addresses_number"`
+	ephemeral          bool
+	EphemeralAddrs     *int64   `toml:"ephemeral_addresses_number"`
+	RootKeyFundsBuffer *big.Int `toml:"root_key_funds_buffer"`
 
 	ABIDir                        string `toml:"abi_dir"`
 	BINDir                        string `toml:"bin_dir"`
@@ -39,7 +41,7 @@ type Config struct {
 	Network                       *Network         `toml:"network"`
 	Networks                      []*Network       `toml:"networks"`
 	NonceManager                  *NonceManagerCfg `toml:"nonce_manager"`
-	TracingEnabled                bool             `toml:"tracing_enabled"`
+	TracingLevel                  string           `toml:"tracing_level"`
 	TraceToJson                   bool             `toml:"trace_to_json"`
 	PendingNonceProtectionEnabled bool             `toml:"pending_nonce_protection_enabled"`
 	// internal fields
@@ -191,6 +193,10 @@ func (c *Config) setEphemeralAddrs() {
 
 	if c.KeyFilePath == "" && *c.EphemeralAddrs != 0 {
 		c.ephemeral = true
+	}
+
+	if c.RootKeyFundsBuffer == nil {
+		c.RootKeyFundsBuffer = DefayltRootKeyFundsWeiBuffer
 	}
 }
 

--- a/config.go
+++ b/config.go
@@ -213,3 +213,12 @@ func (c *Config) IsExperimentEnabled(experiment string) bool {
 	}
 	return false
 }
+
+// GetMaxConcurrency returns the maximum number of concurrent transactions. Root key is excluded from the count.
+func (c *Config) GetMaxConcurrency() int {
+	if c.ephemeral {
+		return int(*c.EphemeralAddrs)
+	}
+
+	return len(c.Network.PrivateKeys) - 1
+}

--- a/config.go
+++ b/config.go
@@ -114,9 +114,6 @@ func ReadConfig() (*Config, error) {
 	} else {
 		cfg.Network.PrivateKeys = append(cfg.Network.PrivateKeys, rootPrivateKey)
 	}
-	if err := readKeyFileConfig(cfg); err != nil {
-		return nil, err
-	}
 	L.Trace().Interface("Config", cfg).Msg("Parsed seth config")
 	return cfg, nil
 }
@@ -163,6 +160,9 @@ func (c *Config) ShoulSaveDeployedContractMap() bool {
 func readKeyFileConfig(cfg *Config) error {
 	cfg.KeyFilePath = os.Getenv("SETH_KEYFILE_PATH")
 	if cfg.KeyFilePath != "" {
+		if cfg.EphemeralAddrs != nil && *cfg.EphemeralAddrs != 0 {
+			return errors.New("SETH_KEYFILE_PATH environment variable is set and ephemeral addresses are enabled, please disable ephemeral addresses or remove the keyfile path from the environment variable. You cannot use both modes at the same time")
+		}
 		if _, err := os.Stat(cfg.KeyFilePath); os.IsNotExist(err) {
 			return nil
 		}

--- a/config.go
+++ b/config.go
@@ -161,7 +161,7 @@ func readKeyFileConfig(cfg *Config) error {
 	cfg.KeyFilePath = os.Getenv("SETH_KEYFILE_PATH")
 	if cfg.KeyFilePath != "" {
 		if cfg.EphemeralAddrs != nil && *cfg.EphemeralAddrs != 0 {
-			return errors.New("SETH_KEYFILE_PATH environment variable is set and ephemeral addresses are enabled, please disable ephemeral addresses or remove the keyfile path from the environment variable. You cannot use both modes at the same time")
+			return fmt.Errorf("SETH_KEYFILE_PATH environment variable is set to '%s' and ephemeral addresses are enabled, please disable ephemeral addresses or remove the keyfile path from the environment variable. You cannot use both modes at the same time", cfg.KeyFilePath)
 		}
 		if _, err := os.Stat(cfg.KeyFilePath); os.IsNotExist(err) {
 			return nil

--- a/config.go
+++ b/config.go
@@ -29,10 +29,9 @@ const (
 
 type Config struct {
 	// ephemeral is internal option used only from code
-	ephemeral             bool
-	EphemeralAddrs        *int64   `toml:"ephemeral_addresses_number"`
-	EphemeralAddrsFunding *big.Int `toml:"ephemeral_addresses_funding"`
-	RootKeyFundsBuffer    *big.Int `toml:"root_key_funds_buffer"`
+	ephemeral          bool
+	EphemeralAddrs     *int64   `toml:"ephemeral_addresses_number"`
+	RootKeyFundsBuffer *big.Int `toml:"root_key_funds_buffer"`
 
 	ABIDir                        string `toml:"abi_dir"`
 	BINDir                        string `toml:"bin_dir"`

--- a/config.go
+++ b/config.go
@@ -184,7 +184,7 @@ func readKeyFileConfig(cfg *Config) error {
 
 func (c *Config) setEphemeralAddrs() {
 	if c.EphemeralAddrs == nil {
-		c.EphemeralAddrs = &DefaultEphemeralAddresses
+		c.EphemeralAddrs = &SixtyEphemeralAddresses
 	}
 
 	if *c.EphemeralAddrs == 0 {
@@ -196,7 +196,7 @@ func (c *Config) setEphemeralAddrs() {
 	}
 
 	if c.RootKeyFundsBuffer == nil {
-		c.RootKeyFundsBuffer = DefayltRootKeyFundsWeiBuffer
+		c.RootKeyFundsBuffer = ZeroRootKeyFundsBuffer
 	}
 }
 

--- a/contract_map.go
+++ b/contract_map.go
@@ -3,10 +3,71 @@ package seth
 import (
 	"io"
 	"os"
+	"strings"
+	"sync"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/pelletier/go-toml/v2"
 )
+
+type ContractMap struct {
+	mu         *sync.RWMutex
+	addressMap map[string]string
+}
+
+func NewEmptyContractMap() ContractMap {
+	return ContractMap{
+		mu:         &sync.RWMutex{},
+		addressMap: map[string]string{},
+	}
+}
+
+func NewContractMap(contracts map[string]string) ContractMap {
+	return ContractMap{
+		mu:         &sync.RWMutex{},
+		addressMap: contracts,
+	}
+}
+
+func (c ContractMap) GetContractMap() map[string]string {
+	return c.addressMap
+}
+
+func (c ContractMap) IsKnownAddress(addr string) bool {
+	return c.addressMap[strings.ToLower(addr)] != ""
+}
+
+func (c ContractMap) GetContractName(addr string) string {
+	return c.addressMap[strings.ToLower(addr)]
+}
+
+func (c ContractMap) GetContractAddress(addr string) string {
+	if addr == UNKNOWN {
+		return UNKNOWN
+	}
+
+	for k, v := range c.addressMap {
+		if v == addr {
+			return k
+		}
+	}
+	return UNKNOWN
+}
+
+func (c ContractMap) AddContract(addr, name string) {
+	if addr == UNKNOWN {
+		return
+	}
+
+	name = strings.TrimSuffix(name, ".abi")
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.addressMap[strings.ToLower(addr)] = name
+}
+
+func (c ContractMap) Size() int {
+	return len(c.addressMap)
+}
 
 func SaveDeployedContract(filename, contractName, address string) error {
 	file, err := os.OpenFile(filename, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0600)

--- a/contract_map.go
+++ b/contract_map.go
@@ -34,10 +34,14 @@ func (c ContractMap) GetContractMap() map[string]string {
 }
 
 func (c ContractMap) IsKnownAddress(addr string) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	return c.addressMap[strings.ToLower(addr)] != ""
 }
 
 func (c ContractMap) GetContractName(addr string) string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	return c.addressMap[strings.ToLower(addr)]
 }
 
@@ -46,6 +50,8 @@ func (c ContractMap) GetContractAddress(addr string) string {
 		return UNKNOWN
 	}
 
+	c.mu.Lock()
+	defer c.mu.Unlock()
 	for k, v := range c.addressMap {
 		if v == addr {
 			return k

--- a/contract_store.go
+++ b/contract_store.go
@@ -30,17 +30,22 @@ func (c *ContractStore) GetABI(name string) (*abi.ABI, bool) {
 	if !strings.HasSuffix(name, ".abi") {
 		name = name + ".abi"
 	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	abi, ok := c.ABIs[name]
 	return &abi, ok
 }
 
 func (c *ContractStore) AddABI(name string, abi abi.ABI) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
 	if !strings.HasSuffix(name, ".abi") {
 		name = name + ".abi"
 	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	c.ABIs[name] = abi
 }
 
@@ -48,17 +53,22 @@ func (c *ContractStore) GetBIN(name string) ([]byte, bool) {
 	if !strings.HasSuffix(name, ".bin") {
 		name = name + ".bin"
 	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	bin, ok := c.BINs[name]
 	return bin, ok
 }
 
 func (c *ContractStore) AddBIN(name string, bin []byte) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
 	if !strings.HasSuffix(name, ".bin") {
 		name = name + ".bin"
 	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	c.BINs[name] = bin
 }
 

--- a/decode.go
+++ b/decode.go
@@ -235,6 +235,8 @@ func (m *Client) DecodeCustomABIErr(txErr error) (string, error) {
 				}
 			}
 		}
+	} else {
+		L.Warn().Msg("No error data in tx")
 	}
 	return "", nil
 }
@@ -272,8 +274,8 @@ func (m *Client) callAndGetRevertReason(tx *types.Transaction, rc *types.Receipt
 	// if there is no match we print the error from CallMsg call
 	_, plainStringErr := m.Client.CallContract(context.Background(), m.CallMsgFromTx(tx), rc.BlockNumber)
 
-	if m.TraceReverted {
-		L.Debug().Msg("Decoding revert error")
+	if m.Cfg.TracingLevel == TracingLevel_Reverted {
+		L.Debug().Str("Tx hash", tx.Hash().Hex()).Msg("Decoding revert error")
 		traceErr := m.Tracer.TraceGethTX(tx.Hash().Hex())
 		if traceErr != nil {
 			L.Warn().Err(traceErr).Msg("Failed to trace transaction")
@@ -288,6 +290,7 @@ func (m *Client) callAndGetRevertReason(tx *types.Transaction, rc *types.Receipt
 		return errors.New(decodedABIErrString)
 	}
 	if plainStringErr != nil {
+		L.Warn().Msg("Failed to decode revert reason")
 		return plainStringErr
 	}
 	return nil

--- a/decode.go
+++ b/decode.go
@@ -274,14 +274,6 @@ func (m *Client) callAndGetRevertReason(tx *types.Transaction, rc *types.Receipt
 	// if there is no match we print the error from CallMsg call
 	_, plainStringErr := m.Client.CallContract(context.Background(), m.CallMsgFromTx(tx), rc.BlockNumber)
 
-	if m.Cfg.TracingLevel == TracingLevel_Reverted {
-		L.Debug().Str("Tx hash", tx.Hash().Hex()).Msg("Decoding revert error")
-		traceErr := m.Tracer.TraceGethTX(tx.Hash().Hex())
-		if traceErr != nil {
-			L.Warn().Err(traceErr).Msg("Failed to trace transaction")
-		}
-	}
-
 	decodedABIErrString, err := m.DecodeCustomABIErr(plainStringErr)
 	if err != nil {
 		return err

--- a/examples/example_tracing_test.go
+++ b/examples/example_tracing_test.go
@@ -20,8 +20,8 @@ func TestDecodeExample(t *testing.T) {
 	c, err := seth.NewClient()
 	require.NoError(t, err, "failed to initalise seth")
 
-	// when this flag is enabled we don't need to call TraceGethTX, because it's called automatically
-	c.Cfg.TracingEnabled = true
+	// when this level is set we don't need to call TraceGethTX, because it's called automatically
+	c.Cfg.TracingLevel = seth.TracingLevel_All
 
 	_, err = c.Decode(contract.TraceDifferent(c.NewTXOpts(), big.NewInt(1), big.NewInt(2)))
 	require.NoError(t, err, "failed to decode transaction")

--- a/gas_adjuster.go
+++ b/gas_adjuster.go
@@ -231,7 +231,7 @@ func (m *Client) GetSuggestedEIP1559Fees(ctx context.Context, priority string) (
 		}
 	}
 
-	if baseFee64 == 0.0 || currentGasTip.Int64() == 0 {
+	if baseFee64 == 0.0 {
 		err = errors.New(ZeroGasSuggestedErr)
 
 		L.Error().
@@ -240,6 +240,11 @@ func (m *Client) GetSuggestedEIP1559Fees(ctx context.Context, priority string) (
 			Int64("SuggestedTip", currentGasTip.Int64()).
 			Msg("Incorrect gas data received from node. Skipping automation gas estimation")
 		return
+	}
+
+	if currentGasTip.Int64() == 0 {
+		L.Warn().
+			Msg("Suggested tip is 0.0. Although not strictly incorrect, it is unusual. Transaction might take much longer to confirm.")
 	}
 
 	// between 0.8 and 1.5

--- a/gas_adjuster.go
+++ b/gas_adjuster.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -29,6 +30,10 @@ const (
 	CongestionStrategy_Simple = "simple"
 	// newer blocks have more weight in the computation
 	CongestionStrategy_NewestFirst = "newest_first"
+)
+
+var (
+	ZeroGasSuggestedErr = "Either base fee or suggested tip is 0"
 )
 
 // CalculateNetworkCongestionMetric calculates a simple congestion metric based on the last N blocks
@@ -227,7 +232,7 @@ func (m *Client) GetSuggestedEIP1559Fees(ctx context.Context, priority string) (
 	}
 
 	if baseFee64 == 0.0 || currentGasTip.Int64() == 0 {
-		err = fmt.Errorf("Either base fee or suggested tip is 0")
+		err = errors.New(ZeroGasSuggestedErr)
 
 		L.Error().
 			Err(err).

--- a/nonce.go
+++ b/nonce.go
@@ -140,9 +140,6 @@ func (m *NonceManager) anySyncedKey() int {
 				m.Client.Errors = append(m.Client.Errors, errors.New(ErrKeySync))
 			}
 		}()
-		if keyData != nil && keyData.KeyNum == 0 {
-			return -1
-		}
 		return keyData.KeyNum
 	}
 }

--- a/nonce.go
+++ b/nonce.go
@@ -93,6 +93,7 @@ func (m *NonceManager) anySyncedKey() int {
 	select {
 	case <-ctx.Done():
 		L.Error().Msg(ErrKeySyncTimeout)
+		m.Client.Errors = append(m.Client.Errors, errors.New(ErrKeySync))
 		return -1
 	case keyData := <-m.SyncedKeys:
 		L.Trace().

--- a/nonce.go
+++ b/nonce.go
@@ -18,6 +18,7 @@ const (
 	ErrKeySyncTimeout = "key sync timeout, consider increasing key_sync_timeout in seth.toml, or increasing the number of keys"
 	ErrKeySync        = "failed to sync the key"
 	ErrNonce          = "failed to get nonce"
+	TimeoutKeyNum     = -80001
 )
 
 // NonceManager tracks nonce for each address
@@ -94,7 +95,7 @@ func (m *NonceManager) anySyncedKey() int {
 	case <-ctx.Done():
 		L.Error().Msg(ErrKeySyncTimeout)
 		m.Client.Errors = append(m.Client.Errors, errors.New(ErrKeySync))
-		return -1
+		return TimeoutKeyNum //so that it's pretty uniqe number of invalid key
 	case keyData := <-m.SyncedKeys:
 		L.Trace().
 			Interface("KeyNum", keyData.KeyNum).

--- a/seth.toml
+++ b/seth.toml
@@ -8,9 +8,15 @@ bin_dir = "contracts/bin"
 # This functionality is not used for simulated networks.
 #contract_map_file = "deployed_contracts_mumbai.toml"
 
-# enables automatic tracing of all transactions that are decoded via Decode() method
-tracing_enabled = false
-# saves each tracing result to json file in ./traces/<tx_hash>.json
+# controls which transactions are decoded/traced. Possbile values are: none, all, reverted (default).
+# if transaction level doesn't match, then calling Decode() does nothing. It's advised to keep it set
+# to 'reverted' to limit noise. If you combine it with 'trace_to_json' it will save all possible data
+# in JSON files for reverted transactions.
+tracing_level = "reverted"
+# saves each decoding/tracing results to JSON files; what exactly is saved depends on what we
+# were able te decode, we try to save maximum information possible. It can either be:
+# just tx hash, decoded transaction or call trace. Which transactions traces are saved depends
+# on 'tracing_level'.
 trace_to_json = false
 # number of addresses to be generated and runtime, if set to 0, no addresses will be generated
 # each generated address will receive a proportion of native tokens from root private key's balance
@@ -18,7 +24,8 @@ trace_to_json = false
 ephemeral_addresses_number = 0
 
 # If enabled we will panic when getting transaction options if current key/address has a pending transaction
-# That's because the one we are about to send would get queued, possibly for a very long time
+# That's because the one we are about to send would get queued, possibly for a very long time. It's best to disable
+# it when running load tests.
 pending_nonce_protection_enabled = false
 
 # Amount to be left on root key/address, when we are using ephemeral addresses. It's the amount that will not

--- a/seth.toml
+++ b/seth.toml
@@ -30,11 +30,17 @@ pending_nonce_protection_enabled = false
 
 # Amount to be left on root key/address, when we are using ephemeral addresses. It's the amount that will not
 # be divided into ephemeral keys.
-root_key_funds_buffer_wei = 10_000_000_000_000_000_000 # 10 eth
+root_key_funds_buffer = 10 # 10 eth
 
 # feature-flagged expriments; first one sets funds return priority to 'slow' (core only!), second one
 # sets the tip/base fee to the higher value in case there's 3+ orders of magnitude difference between them
 experiments_enabled = ["slow_funds_return", "eip_1559_fee_equalizer"]
+
+[nonce_manager]
+key_sync_rate_limit_per_sec = 10
+key_sync_timeout = "20s"
+key_sync_retry_delay = "1s"
+key_sync_retries = 10
 
 [[networks]]
 name = "Anvil"
@@ -162,9 +168,3 @@ gas_price = 50_000_000
 
 gas_fee_cap = 1_800_000_000
 gas_tip_cap = 1_800_000_000
-
-[nonce_manager]
-key_sync_rate_limit_per_sec = 10
-key_sync_timeout = "2s"
-key_sync_retry_delay = "1s"
-key_sync_retries = 10

--- a/seth.toml
+++ b/seth.toml
@@ -30,7 +30,7 @@ pending_nonce_protection_enabled = false
 
 # Amount to be left on root key/address, when we are using ephemeral addresses. It's the amount that will not
 # be divided into ephemeral keys.
-root_key_funds_buffer = 10 # 10 eth
+root_key_funds_buffer = 10 # 10 ether
 
 # feature-flagged expriments; first one sets funds return priority to 'slow' (core only!), second one
 # sets the tip/base fee to the higher value in case there's 3+ orders of magnitude difference between them

--- a/seth.toml
+++ b/seth.toml
@@ -21,6 +21,10 @@ ephemeral_addresses_number = 0
 # That's because the one we are about to send would get queued, possibly for a very long time
 pending_nonce_protection_enabled = false
 
+# Amount to be left on root key/address, when we are using ephemeral addresses. It's the amount that will not
+# be divided into ephemeral keys.
+root_key_funds_buffer_wei = 10_000_000_000_000_000_000 # 10 eth
+
 # feature-flagged expriments; first one sets funds return priority to 'slow' (core only!), second one
 # sets the tip/base fee to the higher value in case there's 3+ orders of magnitude difference between them
 experiments_enabled = ["slow_funds_return", "eip_1559_fee_equalizer"]

--- a/tracing.go
+++ b/tracing.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"sync"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
@@ -39,65 +38,6 @@ type Tracer struct {
 	ContractAddressToNameMap ContractMap
 	DecodedCalls             map[string][]*DecodedCall
 	ABIFinder                *ABIFinder
-}
-
-type ContractMap struct {
-	mu         *sync.RWMutex
-	addressMap map[string]string
-}
-
-func NewEmptyContractMap() ContractMap {
-	return ContractMap{
-		mu:         &sync.RWMutex{},
-		addressMap: map[string]string{},
-	}
-}
-
-func NewContractMap(contracts map[string]string) ContractMap {
-	return ContractMap{
-		mu:         &sync.RWMutex{},
-		addressMap: contracts,
-	}
-}
-
-func (c ContractMap) GetContractMap() map[string]string {
-	return c.addressMap
-}
-
-func (c ContractMap) IsKnownAddress(addr string) bool {
-	return c.addressMap[strings.ToLower(addr)] != ""
-}
-
-func (c ContractMap) GetContractName(addr string) string {
-	return c.addressMap[strings.ToLower(addr)]
-}
-
-func (c ContractMap) GetContractAddress(addr string) string {
-	if addr == UNKNOWN {
-		return UNKNOWN
-	}
-
-	for k, v := range c.addressMap {
-		if v == addr {
-			return k
-		}
-	}
-	return UNKNOWN
-}
-
-func (c ContractMap) AddContract(addr, name string) {
-	if addr == UNKNOWN {
-		return
-	}
-
-	name = strings.TrimSuffix(name, ".abi")
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.addressMap[strings.ToLower(addr)] = name
-}
-
-func (c ContractMap) Size() int {
-	return len(c.addressMap)
 }
 
 type Trace struct {

--- a/tracing.go
+++ b/tracing.go
@@ -341,16 +341,6 @@ func (t *Tracer) DecodeTrace(l zerolog.Logger, trace Trace) ([]*DecodedCall, err
 	}
 
 	t.DecodedCalls[trace.TxHash] = decodedCalls
-
-	// if t.Cfg.TraceToJson {
-	// 	saveErr := t.SaveDecodedCallsAsJson("traces")
-	// 	if saveErr != nil {
-	// 		L.Warn().
-	// 			Err(saveErr).
-	// 			Msg("Failed to save decoded calls as JSON")
-	// 	}
-	// }
-
 	return decodedCalls, nil
 }
 

--- a/util.go
+++ b/util.go
@@ -377,10 +377,11 @@ func wrapErrInMessageWithASuggestion(err error) error {
 
 This error could be caused by several issues. Please try these steps to resolve it:
 
-1. Use a different RPC node. The current one might be out of sync or malfunctioning.
-2. Review the logs to see if automatic gas estimations were unsuccessful. If they were, check that the fallback gas prices are set correctly.
-3. If a gas limit was manually set, try commenting it out to let the node estimate it instead and see if that resolves the issue.
-4. Conversely, if a gas limit was set manually, try increasing it to a higher value. This adjustment is especially crucial for some Layer 2 solutions that have variable gas limits.
+1. Make sure the address you are using has sufficient funds.
+2. Use a different RPC node. The current one might be out of sync or malfunctioning.
+3. Review the logs to see if automatic gas estimations were unsuccessful. If they were, check that the fallback gas prices are set correctly.
+4. If a gas limit was manually set, try commenting it out to let the node estimate it instead and see if that resolves the issue.
+5. Conversely, if a gas limit was set manually, try increasing it to a higher value. This adjustment is especially crucial for some Layer 2 solutions that have variable gas limits.
 
 Original error:`
 	return fmt.Errorf("%s\n%s", message, err.Error())

--- a/util.go
+++ b/util.go
@@ -70,7 +70,17 @@ func (m *Client) CalculateSubKeyFunding(addrs int64) (*FundingDetails, error) {
 	if err != nil {
 		return nil, err
 	}
-	networkTransferFee := m.Cfg.Network.GasPrice * m.Cfg.Network.TransferGasFee
+
+	gasLimit := m.Cfg.Network.TransferGasFee
+	newAddress, _, err := NewAddress()
+	if err == nil {
+		gasLimitRaw, err := m.EstimateGasLimitForFundTransfer(m.Addresses[0], common.HexToAddress(newAddress), big.NewInt(0).Quo(balance, big.NewInt(addrs)))
+		if err == nil {
+			gasLimit = int64(gasLimitRaw)
+		}
+	}
+
+	networkTransferFee := m.Cfg.Network.GasPrice * gasLimit
 	totalFee := new(big.Int).Mul(big.NewInt(networkTransferFee), big.NewInt(addrs))
 	rootKeyBuffer := new(big.Int).Mul(m.Cfg.RootKeyFundsBuffer, big.NewInt(1_000_000_000_000_000_000))
 	freeBalance := new(big.Int).Sub(balance, big.NewInt(0).Add(totalFee, rootKeyBuffer))

--- a/util.go
+++ b/util.go
@@ -16,7 +16,6 @@ import (
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/pelletier/go-toml/v2"
 	"github.com/pkg/errors"
-	"github.com/smartcontractkit/chainlink-testing-framework/utils/conversions"
 	network_debug_contract "github.com/smartcontractkit/seth/contracts/bind/debug"
 	network_sub_debug_contract "github.com/smartcontractkit/seth/contracts/bind/sub"
 )
@@ -77,10 +76,10 @@ func (m *Client) CalculateSubKeyFunding(addrs int64) (*FundingDetails, error) {
 	freeBalance := new(big.Int).Sub(balance, big.NewInt(0).Add(totalFee, rootKeyBuffer))
 
 	L.Info().
-		Str("Balance (wei/ether)", fmt.Sprintf("%s/%s", balance.String(), conversions.WeiToEther(balance).Text('f', -1))).
-		Str("Total fee (wei/ether)", fmt.Sprintf("%s/%s", totalFee.String(), conversions.WeiToEther(totalFee).Text('f', -1))).
-		Str("Free Balance (wei/ether)", fmt.Sprintf("%s/%s", freeBalance.String(), conversions.WeiToEther(freeBalance).Text('f', -1))).
-		Str("Buffer (wei/ether)", fmt.Sprintf("%s/%s", rootKeyBuffer.String(), conversions.WeiToEther(rootKeyBuffer).Text('f', -1))).
+		Str("Balance (wei/ether)", fmt.Sprintf("%s/%s", balance.String(), WeiToEther(balance).Text('f', -1))).
+		Str("Total fee (wei/ether)", fmt.Sprintf("%s/%s", totalFee.String(), WeiToEther(totalFee).Text('f', -1))).
+		Str("Free Balance (wei/ether)", fmt.Sprintf("%s/%s", freeBalance.String(), WeiToEther(freeBalance).Text('f', -1))).
+		Str("Buffer (wei/ether)", fmt.Sprintf("%s/%s", rootKeyBuffer.String(), WeiToEther(rootKeyBuffer).Text('f', -1))).
 		Msg("Root key balance")
 
 	if freeBalance.Cmp(big.NewInt(0)) < 0 {
@@ -91,9 +90,9 @@ func (m *Client) CalculateSubKeyFunding(addrs int64) (*FundingDetails, error) {
 	requiredBalance := big.NewInt(0).Mul(addrFunding, big.NewInt(addrs))
 
 	L.Debug().
-		Str("Funding per ephemeral key (wei/ether)", fmt.Sprintf("%s/%s", addrFunding.String(), conversions.WeiToEther(addrFunding).Text('f', -1))).
-		Str("Available balance (wei/ether)", fmt.Sprintf("%s/%s", freeBalance.String(), conversions.WeiToEther(freeBalance).Text('f', -1))).
-		Interface("Required balance (wei/ether)", fmt.Sprintf("%s/%s", requiredBalance.String(), conversions.WeiToEther(requiredBalance).Text('f', -1))).
+		Str("Funding per ephemeral key (wei/ether)", fmt.Sprintf("%s/%s", addrFunding.String(), WeiToEther(addrFunding).Text('f', -1))).
+		Str("Available balance (wei/ether)", fmt.Sprintf("%s/%s", freeBalance.String(), WeiToEther(freeBalance).Text('f', -1))).
+		Interface("Required balance (wei/ether)", fmt.Sprintf("%s/%s", requiredBalance.String(), WeiToEther(requiredBalance).Text('f', -1))).
 		Msg("Using hardcoded ephemeral funding")
 
 	if freeBalance.Cmp(requiredBalance) < 0 {

--- a/util.go
+++ b/util.go
@@ -371,3 +371,17 @@ func WeiToEther(wei *big.Int) *big.Float {
 	fWei.SetMode(big.ToNearestEven)
 	return f.Quo(fWei.SetInt(wei), big.NewFloat(params.Ether))
 }
+
+func wrapErrInMessageWithASuggestion(err error) error {
+	message := `
+
+This error could be caused by several issues. Please try these steps to resolve it:
+
+1. Use a different RPC node. The current one might be out of sync or malfunctioning.
+2. Review the logs to see if automatic gas estimations were unsuccessful. If they were, check that the fallback gas prices are set correctly.
+3. If a gas limit was manually set, try commenting it out to let the node estimate it instead and see if that resolves the issue.
+4. Conversely, if a gas limit was set manually, try increasing it to a higher value. This adjustment is especially crucial for some Layer 2 solutions that have variable gas limits.
+
+Original error:`
+	return fmt.Errorf("%s\n%s", message, err.Error())
+}

--- a/util.go
+++ b/util.go
@@ -200,13 +200,13 @@ func NewKeyFile() *KeyFile {
 }
 
 // Duration is a non-negative time duration.
-type Duration struct{ d time.Duration }
+type Duration struct{ D time.Duration }
 
 func MakeDuration(d time.Duration) (Duration, error) {
 	if d < time.Duration(0) {
 		return Duration{}, fmt.Errorf("cannot make negative time duration: %s", d)
 	}
-	return Duration{d: d}, nil
+	return Duration{D: d}, nil
 }
 
 func ParseDuration(s string) (Duration, error) {
@@ -228,7 +228,7 @@ func MustMakeDuration(d time.Duration) *Duration {
 
 // Duration returns the value as the standard time.Duration value.
 func (d Duration) Duration() time.Duration {
-	return d.d
+	return d.D
 }
 
 // Before returns the time d units before time t
@@ -237,10 +237,10 @@ func (d Duration) Before(t time.Time) time.Time {
 }
 
 // Shorter returns true if and only if d is shorter than od.
-func (d Duration) Shorter(od Duration) bool { return d.d < od.d }
+func (d Duration) Shorter(od Duration) bool { return d.D < od.D }
 
 // IsInstant is true if and only if d is of duration 0
-func (d Duration) IsInstant() bool { return d.d == 0 }
+func (d Duration) IsInstant() bool { return d.D == 0 }
 
 // String returns a string representing the duration in the form "72h3m0.5s".
 // Leading zero units are omitted. As a special case, durations less than one
@@ -285,12 +285,12 @@ func (d *Duration) Scan(v interface{}) (err error) {
 }
 
 func (d Duration) Value() (driver.Value, error) {
-	return int64(d.d), nil
+	return int64(d.D), nil
 }
 
 // MarshalText implements the text.Marshaler interface.
 func (d Duration) MarshalText() ([]byte, error) {
-	return []byte(d.d.String()), nil
+	return []byte(d.D.String()), nil
 }
 
 // UnmarshalText implements the text.Unmarshaler interface.


### PR DESCRIPTION
* add a root key buffer, which is an amount that will be left on root key and won't be split between ephemeral keys
* simplified tracing configuration, now we just have `tracing_level` which can be `all`, `none` or `reverted` (default one)
* return `-80001` when key syncing fails instead of `0` to signal failure and avoid using root key and add that error to slice in the client, so that next time we check it (e.g. when `Decode() runs) it will exit with error
* protect contract and ABI/BIN maps from concurrent writes with mutex
* fixed int64 overflow in balance comparison that resulted in false positives (insufficient balance, when the number was too high)
* estimate gas limit on fund transfer and use hardcoded one only as a fallback (needed as some L2s need different gas limits depending whether address exists or needs to be created; also on Ethereum when sending funds to contracts that have `receive()` method we will need more than 21k gas)
* don't exit with error when suggested tip is `0`, display warning and continue (happens on Arb, but txs are still fast)
* auto-disable gas estimations if they fail because one of the endpoints we need is not implemented
* dedicated method to get max possible concurrency count based on ephemeral/static keys count that excludes root key
* add errors to `Context` in methods that cannot return an error, because they cannot have an `error` in the signature, that way we can later check if error is present in context and take some actions (in `chainlink` I check it in the wrapper before interacting with contract to avoid hard to understand error messages when we send a transaction with empty options)