### PR TITLE
Disable EIP-1559 if not supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,13 +157,11 @@ urls_secret = ["..."]
 # if set to true we will check if address has a pending nonce (transaction) and panic if it does
 pending_nonce_protection_enabled = false
 # if set to true we will dynamically estimate gas for every transaction (explained in more detail below)
-gas_estimation_enabled = true
+gas_price_estimation_enabled = true
 # how many last blocks to use, when estimating gas for a transaction
-gas_estimation_blocks = 1000
-# maximum price we are willing to pay for a transaction (will be used to calculate gas price or tip/fee cap according to gas limit)
-gas_estimation_max_tx_cost_wei = 10_000_000_000
+gas_price_estimation_blocks = 1000
 # priority of the transaction, can be "fast", "standard" or "slow" (the higher the priority, the higher adjustment factor and buffer will be used for gas estimation) [default: "standard"]
-gas_estimation_tx_priority = "slow"
+gas_price_estimation_tx_priority = "slow"
 ```
 
 If you want to save addresses of deployed contracts, you can enable it with:
@@ -261,28 +259,47 @@ You can read more about how ABI finding and contract map works [here](./docs/abi
 
 ### Autmoatic gas estimator
 
-Regardless whether you are using automatic gas estimator or not, you still need to set all expected default gas-related values for your network. If it doesn't support EIP-1559, you need to set `gas_price` and if it does, you need to set `eip_1559_dynamic_fees`, `gas_fee_cap`, `gas_tip_cap`. They will be used as fallback in case gas estimation fails. `gas_limit` and `transfer_gas_fee` are also required.
+This section explains how to configure and understand the automatic gas estimator, which is crucial for executing transactions on Ethereum-based networks. Here’s what you need to know:
 
-Now, how does gas estimation work?
+#### Configuration Requirements
 
-First of all, if network is simulated, we never estimate gas, but use hardcoded values. Otherwise...
+Before using the automatic gas estimator, it's essential to set the default gas-related parameters for your network:
 
-#### Legacy transactions
-1. We ask the node for suggested gas price.
-2. We modify it based on `gas_estimation_tx_priority`. The higher the priority, the higher the adjustment factor (details below).
-3. We fetch last `gas_estimation_blocks` (number) of block headers and calculate congestion rate for each block using a logarithmic function that gives higher weight to the most recent block headers. Congestion rate is gas used/gas limit.
-4. Based on congestion rate, we add a buffer to gas price to make sure the transaction is included in the block (details below).
+- **Non-EIP-1559 Networks**: Set the `gas_price` to define the cost per unit of gas if your network doesn't support EIP-1559.
+- **EIP-1559 Networks**: If your network supports EIP-1559, set the following:
+  - `eip_1559_dynamic_fees`: Enables dynamic fee structure.
+  - `gas_fee_cap`: The maximum fee you're willing to pay per gas.
+  - `gas_tip_cap`: An optional tip to prioritize your transaction within a block (although if it's set to `0` there's a high chance your transaction will take longer to execute as it will be less attractive to miners, so do set it).
 
-#### EIP-1559 transactions
-1. We ask the node for suggested tip fee.
-2. We get base fee and tip history for last `gas_estimation_blocks` (number) of block headers.
-3. We then take the higher of suggested tip fee and historical tip fee and use the for further calculations.
-4. Based on `gas_estimation_tx_priority` we adjust the tip and base fee. The higher the priority, the higher the adjustment factor (details below).
-5. We sum base fee and the tip to get the gas fee cap.
-6. We fetch last `gas_estimation_blocks` (number) of block headers and calculate congestion rate for each block using a logarithmic function that gives higher weight to the most recent block headers. Congestion rate is gas used/gas limit.
-7. Based on congestion rate, we add a buffer to both fee cao and tip to make sure the transaction is included in the block (details below).
+These settings act as a fallback if the gas estimation fails. Additionally, always specify `transfer_gas_fee` for the fee associated with token transfers.
 
-Finally, `gas_estimation_tx_priority` is also used, when deciding, which percentile to use for base fee and tip for historical fee data. Here's how that looks:
+If you do not know if your network supports EIP-1559, but you want to give it a try it's recommended that you also set `gas_price` as a fallback. When we try to use EIP-1559 during gas price estimation, but it fails, we will fallback to using non-EIP-1559 logic. If that one fails as well, we will use hardcoded `gas_price` value.
+
+#### How Gas Estimation Works
+
+Gas estimation varies based on whether the network is a private Ethereum Network or a live network.
+
+- **Private Ethereum Networks**: no estimation is needed. We always use hardcoded values.
+
+For real networks, the estimation process differs for legacy transactions and those compliant with EIP-1559:
+
+##### Legacy Transactions
+1. **Initial Price**: Query the network node for the current suggested gas price.
+2. **Priority Adjustment**: Modify the initial price based on `gas_price_estimation_tx_priority`. Higher priority increases the price to ensure faster inclusion in a block.
+3. **Congestion Analysis**: Examine the last X blocks (as specified by `gas_price_estimation_blocks`) to determine network congestion, calculating the usage rate of gas in each block and giving recent blocks more weight.
+4. **Buffering**: Add a buffer to the adjusted gas price to increase transaction reliability during high congestion.
+
+##### EIP-1559 Transactions
+1. **Tip Fee Query**: Ask the node for the current recommended tip fee.
+2. **Fee History Analysis**: Gather the base fee and tip history from recent blocks to establish a fee baseline.
+3. **Fee Selection**: Use the greater of the node's suggested tip or the historical average tip for upcoming calculations.
+4. **Priority and Adjustment**: Increase the base and tip fees based on transaction priority (`gas_price_estimation_tx_priority`), which influences how much you are willing to spend to expedite your transaction.
+5. **Final Fee Calculation**: Sum the base fee and adjusted tip to set the `gas_fee_cap`.
+6. **Congestion Buffer**: Similar to legacy transactions, analyze congestion and apply a buffer to both the fee cap and the tip to secure transaction inclusion.
+
+Understanding and setting these parameters correctly ensures that your transactions are processed efficiently and cost-effectively on the network.
+
+Finally, `gas_price_estimation_tx_priority` is also used, when deciding, which percentile to use for base fee and tip for historical fee data. Here's how that looks:
 ```go
 		case Priority_Fast:
 			baseFee = stats.GasPrice.Perc99
@@ -296,7 +313,7 @@ Finally, `gas_estimation_tx_priority` is also used, when deciding, which percent
 ```
 
 ##### Adjustment factor
-All values are multiplied by the adjustment factor, which is calculated based on `gas_estimation_tx_priority`:
+All values are multiplied by the adjustment factor, which is calculated based on `gas_price_estimation_tx_priority`:
 ```go
 	case Priority_Fast:
 		return 1.2
@@ -319,7 +336,7 @@ We further adjust the gas price by adding a buffer to it, based on congestion ra
 		return 0.40, nil
 ```
 
-We cache block header data in an in-memory cache, so we don't have to fetch it every time we estimate gas. The cache has capacity equal to `gas_estimation_blocks` and every time we add a new element, we remove one that is least frequently used and oldest (with block number being a constant and chain always moving forward it makes no sense to keep old blocks).
+We cache block header data in an in-memory cache, so we don't have to fetch it every time we estimate gas. The cache has capacity equal to `gas_price_estimation_blocks` and every time we add a new element, we remove one that is least frequently used and oldest (with block number being a constant and chain always moving forward it makes no sense to keep old blocks).
 
 For both transaction types if any of the steps fails, we fallback to hardcoded values.
 

--- a/config.go
+++ b/config.go
@@ -57,20 +57,20 @@ type NonceManagerCfg struct {
 }
 
 type Network struct {
-	Name                    string    `toml:"name"`
-	ChainID                 string    `toml:"chain_id"`
-	URLs                    []string  `toml:"urls_secret"`
-	EIP1559DynamicFees      bool      `toml:"eip_1559_dynamic_fees"`
-	GasPrice                int64     `toml:"gas_price"`
-	GasFeeCap               int64     `toml:"gas_fee_cap"`
-	GasTipCap               int64     `toml:"gas_tip_cap"`
-	GasLimit                uint64    `toml:"gas_limit"`
-	TxnTimeout              *Duration `toml:"transaction_timeout"`
-	TransferGasFee          int64     `toml:"transfer_gas_fee"`
-	PrivateKeys             []string  `toml:"private_keys_secret"`
-	GasEstimationEnabled    bool      `toml:"gas_estimation_enabled"`
-	GasEstimationBlocks     uint64    `toml:"gas_estimation_blocks"`
-	GasEstimationTxPriority string    `toml:"gas_estimation_tx_priority"`
+	Name                         string    `toml:"name"`
+	ChainID                      string    `toml:"chain_id"`
+	URLs                         []string  `toml:"urls_secret"`
+	EIP1559DynamicFees           bool      `toml:"eip_1559_dynamic_fees"`
+	GasPrice                     int64     `toml:"gas_price"`
+	GasFeeCap                    int64     `toml:"gas_fee_cap"`
+	GasTipCap                    int64     `toml:"gas_tip_cap"`
+	GasLimit                     uint64    `toml:"gas_limit"`
+	TxnTimeout                   *Duration `toml:"transaction_timeout"`
+	TransferGasFee               int64     `toml:"transfer_gas_fee"`
+	PrivateKeys                  []string  `toml:"private_keys_secret"`
+	GasPriceEstimationEnabled    bool      `toml:"gas_price_estimation_enabled"`
+	GasPriceEstimationBlocks     uint64    `toml:"gas_price_estimation_blocks"`
+	GasPriceEstimationTxPriority string    `toml:"gas_price_estimation_tx_priority"`
 }
 
 // ReadConfig reads the TOML config file from location specified by env var "SETH_CONFIG_PATH" and returns a Config struct

--- a/gas_adjuster.go
+++ b/gas_adjuster.go
@@ -253,7 +253,7 @@ func (m *Client) GetSuggestedEIP1559Fees(ctx context.Context, priority string) (
 
 	// between 0 and 1 (empty blocks - full blocks)
 	var congestionMetric float64
-	congestionMetric, err = m.CalculateNetworkCongestionMetric(m.Cfg.Network.GasEstimationBlocks, CongestionStrategy_NewestFirst)
+	congestionMetric, err = m.CalculateNetworkCongestionMetric(m.Cfg.Network.GasPriceEstimationBlocks, CongestionStrategy_NewestFirst)
 	if err != nil {
 		return
 	}
@@ -354,7 +354,7 @@ func (m *Client) GetSuggestedLegacyFees(ctx context.Context, priority string) (a
 
 	// between 0 and 1 (empty blocks - full blocks)
 	var congestionMetric float64
-	congestionMetric, err = m.CalculateNetworkCongestionMetric(m.Cfg.Network.GasEstimationBlocks, CongestionStrategy_NewestFirst)
+	congestionMetric, err = m.CalculateNetworkCongestionMetric(m.Cfg.Network.GasPriceEstimationBlocks, CongestionStrategy_NewestFirst)
 	if err != nil {
 		return
 	}
@@ -443,7 +443,7 @@ func classifyCongestion(congestionMetric float64) string {
 
 func (m *Client) HistoricalFeeData(priority string) (baseFee float64, historicalGasTipCap float64, err error) {
 	estimator := NewGasEstimator(m)
-	stats, err := estimator.Stats(m.Cfg.Network.GasEstimationBlocks, 99)
+	stats, err := estimator.Stats(m.Cfg.Network.GasPriceEstimationBlocks, 99)
 	if err != nil {
 		L.Error().
 			Err(err).

--- a/gas_adjuster.go
+++ b/gas_adjuster.go
@@ -379,9 +379,9 @@ func (m *Client) GetSuggestedLegacyFees(ctx context.Context, priority string) (a
 	adjustedGasPrice = new(big.Int).Add(adjustedGasPrice, bufferInt)
 
 	L.Debug().
-		Str("Diff (Wei/Ether)", fmt.Sprintf("%s/%s", big.NewInt(0).Sub(adjustedGasPrice, suggestedGasPrice).String(), WeiToEther(big.NewInt(0).Sub(adjustedGasPrice, suggestedGasPrice)))).
-		Str("Initial GasPrice (Wei/Ether)", fmt.Sprintf("%s/%s", suggestedGasPrice.String(), WeiToEther(suggestedGasPrice))).
-		Str("Final GasPrice (Wei/Ether)", fmt.Sprintf("%s/%s", adjustedGasPrice.String(), WeiToEther(adjustedGasPrice))).
+		Str("Diff (Wei/Ether)", fmt.Sprintf("%s/%s", big.NewInt(0).Sub(adjustedGasPrice, suggestedGasPrice).String(), WeiToEther(big.NewInt(0).Sub(adjustedGasPrice, suggestedGasPrice)).Text('f', -1))).
+		Str("Initial GasPrice (Wei/Ether)", fmt.Sprintf("%s/%s", suggestedGasPrice.String(), WeiToEther(suggestedGasPrice).Text('f', -1))).
+		Str("Final GasPrice (Wei/Ether)", fmt.Sprintf("%s/%s", adjustedGasPrice.String(), WeiToEther(adjustedGasPrice).Text('f', -1))).
 		Msg("Suggested Legacy fees")
 
 	L.Debug().

--- a/seth.toml
+++ b/seth.toml
@@ -60,16 +60,16 @@ transaction_timeout = "30s"
 eip_1559_dynamic_fees = true
 
 # automated gas estimation
-gas_estimation_enabled = true
-gas_estimation_blocks = 100
-gas_estimation_tx_priority = "standard"
+gas_price_estimation_enabled = true
+gas_price_estimation_blocks = 100
+gas_price_estimation_tx_priority = "standard"
 
 # gas limits
 transfer_gas_fee = 21_000
 # gas limit should be explicitly set only if you are connecting to a node that's incapable of estimating gas limit itself (should only happen for very old versions)
 # gas_limit = 8_000_000
 
-# manual settings, used when gas_estimation_enabled is false or when it fails
+# manual settings, used when gas_price_estimation_enabled is false or when it fails
 # legacy transactions
 gas_price = 30_000_000_000
 # EIP-1559 transactions
@@ -84,16 +84,16 @@ transaction_timeout = "30s"
 eip_1559_dynamic_fees = true
 
 # automated gas estimation
-gas_estimation_enabled = true
-gas_estimation_blocks = 100
-gas_estimation_tx_priority = "standard"
+gas_price_estimation_enabled = true
+gas_price_estimation_blocks = 100
+gas_price_estimation_tx_priority = "standard"
 
 # gas limits
 transfer_gas_fee = 21_000
 # gas limit should be explicitly set only if you are connecting to a node that's incapable of estimating gas limit itself (should only happen for very old versions)
 # gas_limit = 14_000_000
 
-# manual settings, used when gas_estimation_enabled is false or when it fails
+# manual settings, used when gas_price_estimation_enabled is false or when it fails
 # legacy transactions
 gas_price = 1_000_000_000
 # EIP-1559 transactions
@@ -109,18 +109,18 @@ eip_1559_dynamic_fees = true
 
 # automated gas estimation for live networks
 # if set to true we will dynamically estimate gas for every transaction (based on suggested values, priority and congestion rate for last X blocks)
-gas_estimation_enabled = true
+gas_price_estimation_enabled = true
 # number of blocks to use for congestion rate estimation (it will determine buffer added on top of suggested values)
-gas_estimation_blocks = 100
+gas_price_estimation_blocks = 100
 # transaction priority, which determines adjustment factor multiplier applied to suggested values (fast - 1.2x, standard - 1x, slow - 0.8x)
-gas_estimation_tx_priority = "standard"
+gas_price_estimation_tx_priority = "standard"
 
 # gas limits
 transfer_gas_fee = 21_000
 # gas limit should be explicitly set only if you are connecting to a node that's incapable of estimating gas limit itself (should only happen for very old versions)
 # gas_limit = 7_000_000
 
-# manual settings, used when gas_estimation_enabled is false or when it fails
+# manual settings, used when gas_price_estimation_enabled is false or when it fails
 # # legacy transactions
 gas_price = 30460480821
 # # EIP-1559 transactions
@@ -135,16 +135,16 @@ transaction_timeout = "30s"
 eip_1559_dynamic_fees = false
 
 # automated gas estimation
-gas_estimation_enabled = true
-gas_estimation_blocks = 100
-gas_estimation_tx_priority = "standard"
+gas_price_estimation_enabled = true
+gas_price_estimation_blocks = 100
+gas_price_estimation_tx_priority = "standard"
 
 # gas limits
 transfer_gas_fee = 21_000
 # gas limit should be explicitly set only if you are connecting to a node that's incapable of estimating gas limit itself (should only happen for very old versions)
 # gas_limit = 3_000_000
 
-# manual settings, used when gas_estimation_enabled is false or when it fails
+# manual settings, used when gas_price_estimation_enabled is false or when it fails
 # legacy transactions
 gas_price = 50_000_000
 # EIP-1559 transactions


### PR DESCRIPTION
* automatically disable EIP-1559 when we detect that it's not supported
* rename gas-related variables to make them easier to understand