### PR TITLE
chore: github action version bumps

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,7 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       - uses: cachix/install-nix-action@v18
         with:
           nix_path: nixpkgs=channel:nixos-unstable

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
-      - uses: cachix/install-nix-action@v18
+      - uses: cachix/install-nix-action@8887e596b4ee1134dae06b98d573bd674693f47c # v26
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - name: Run tests

--- a/.github/workflows/test_api.yml
+++ b/.github/workflows/test_api.yml
@@ -14,7 +14,7 @@ jobs:
       ROOT_PRIVATE_KEY: ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
-      - uses: cachix/install-nix-action@v18
+      - uses: cachix/install-nix-action@8887e596b4ee1134dae06b98d573bd674693f47c # v26
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - name: Run tests

--- a/.github/workflows/test_api.yml
+++ b/.github/workflows/test_api.yml
@@ -13,7 +13,7 @@ jobs:
     env:
       ROOT_PRIVATE_KEY: ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       - uses: cachix/install-nix-action@v18
         with:
           nix_path: nixpkgs=channel:nixos-unstable

--- a/.github/workflows/test_cli.yml
+++ b/.github/workflows/test_cli.yml
@@ -14,7 +14,7 @@ jobs:
       ROOT_PRIVATE_KEY: ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
-      - uses: cachix/install-nix-action@v18
+      - uses: cachix/install-nix-action@8887e596b4ee1134dae06b98d573bd674693f47c # v26
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - name: Run tests

--- a/.github/workflows/test_cli.yml
+++ b/.github/workflows/test_cli.yml
@@ -13,7 +13,7 @@ jobs:
     env:
       ROOT_PRIVATE_KEY: ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       - uses: cachix/install-nix-action@v18
         with:
           nix_path: nixpkgs=channel:nixos-unstable

--- a/.github/workflows/test_decode.yml
+++ b/.github/workflows/test_decode.yml
@@ -14,7 +14,7 @@ jobs:
       ROOT_PRIVATE_KEY: ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
-      - uses: cachix/install-nix-action@v18
+      - uses: cachix/install-nix-action@8887e596b4ee1134dae06b98d573bd674693f47c # v26
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - name: Run tests

--- a/.github/workflows/test_decode.yml
+++ b/.github/workflows/test_decode.yml
@@ -13,7 +13,7 @@ jobs:
     env:
       ROOT_PRIVATE_KEY: ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       - uses: cachix/install-nix-action@v18
         with:
           nix_path: nixpkgs=channel:nixos-unstable

--- a/.github/workflows/test_decode_testnet.yml
+++ b/.github/workflows/test_decode_testnet.yml
@@ -16,7 +16,7 @@ jobs:
         network: [ Fuji ]
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
-      - uses: cachix/install-nix-action@v18
+      - uses: cachix/install-nix-action@8887e596b4ee1134dae06b98d573bd674693f47c # v26
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - name: Run tests

--- a/.github/workflows/test_decode_testnet.yml
+++ b/.github/workflows/test_decode_testnet.yml
@@ -15,7 +15,7 @@ jobs:
         # TODO: Mumbai is not working right now
         network: [ Fuji ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       - uses: cachix/install-nix-action@v18
         with:
           nix_path: nixpkgs=channel:nixos-unstable

--- a/.github/workflows/test_others.yml
+++ b/.github/workflows/test_others.yml
@@ -14,7 +14,7 @@ jobs:
       ROOT_PRIVATE_KEY: ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
-      - uses: cachix/install-nix-action@v18
+      - uses: cachix/install-nix-action@8887e596b4ee1134dae06b98d573bd674693f47c # v26
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - name: Run tests

--- a/.github/workflows/test_others.yml
+++ b/.github/workflows/test_others.yml
@@ -13,7 +13,7 @@ jobs:
     env:
       ROOT_PRIVATE_KEY: ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       - uses: cachix/install-nix-action@v18
         with:
           nix_path: nixpkgs=channel:nixos-unstable

--- a/.github/workflows/test_trace.yml
+++ b/.github/workflows/test_trace.yml
@@ -14,7 +14,7 @@ jobs:
       ROOT_PRIVATE_KEY: ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
     steps:
       - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
-      - uses: cachix/install-nix-action@v18
+      - uses: cachix/install-nix-action@8887e596b4ee1134dae06b98d573bd674693f47c # v26
         with:
           nix_path: nixpkgs=channel:nixos-unstable
       - name: Run tests

--- a/.github/workflows/test_trace.yml
+++ b/.github/workflows/test_trace.yml
@@ -13,7 +13,7 @@ jobs:
     env:
       ROOT_PRIVATE_KEY: ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       - uses: cachix/install-nix-action@v18
         with:
           nix_path: nixpkgs=channel:nixos-unstable


### PR DESCRIPTION
 ## What

Updating Github Action references in all workflows.

## Why

Github Actions node16 deprecation. See [blog post (github.blog)](https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/)
> Node16 has been out of support since [September 2023](https://github.com/nodejs/Release/#end-of-life-releases). As a result we have started the deprecation process of Node16 for GitHub Actions. We plan to migrate all actions to run on Node20 by Spring 2024.
> Following on from our [warning in workflows using Node16](https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/) we will start enforcing the use of Node20 rather than Node16 on the 13th of May.

## Notes

RE-2531


Outdated Dependency Paths:

```
[ERROR] Deprecated dependencies found (7)!!
lint.yml -> golangci -> actions/checkout@v3 -> node16
test_api.yml -> test -> actions/checkout@v3 -> node16
test_cli.yml -> test -> actions/checkout@v3 -> node16
test_decode.yml -> test -> actions/checkout@v3 -> node16
test_decode_testnet.yml -> test -> actions/checkout@v3 -> node16
test_others.yml -> test -> actions/checkout@v3 -> node16
test_trace.yml -> test -> actions/checkout@v3 -> node16
```

