### PR TITLE
[TT-1170] keys split -> keys fund

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,19 +230,19 @@ alias seth="SETH_CONFIG_PATH=seth.toml go run cmd/seth/seth.go"
 
 Create a new `keyfile` with 10 new accounts funded from the root key (KEYS env var)
 ```
-seth -n Geth keys split -a 10
+SETH_ROOT_PRIVATE_KEY=ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 SETH_KEYFILE_PATH=keyfile.toml seth -n Geth keys fund -a 10 [-b 2]
 ```
 Run the tests, then return funds back, when needed
 ```
-seth -n Geth keys return
+SETH_ROOT_PRIVATE_KEY=ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 SETH_KEYFILE_PATH=keyfile.toml seth -n Geth keys return
 ```
 Update the balances
 ```
-seth -n Geth keys update
+SETH_ROOT_PRIVATE_KEY=ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 SETH_KEYFILE_PATH=keyfile.toml seth -n Geth keys update
 ```
 Remove the `keyfile`
 ```
-seth -n Geth keys remove
+SETH_ROOT_PRIVATE_KEY=ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80 SETH_KEYFILE_PATH=keyfile.toml seth -n Geth keys remove
 ```
 ### Manual gas price estimation
 In order to adjust gas price for a transaction, you can use `seth gas` command
@@ -271,25 +271,25 @@ rpc_requests_per_second_limit = 5
 
 Then check the stats for the last N blocks
 ```bash
-SETH_CONFIG_PATH=seth.toml seth -n MyCustomNetwork stats -s -10
+seth -n MyCustomNetwork stats -s -10
 ```
 
 To check stats for the interval (A, B)
 ```bash
-SETH_CONFIG_PATH=seth.toml seth -n MyCustomNetwork stats -s A -e B
+seth -n MyCustomNetwork stats -s A -e B
 ```
 
 #### Pass all network parameters via env vars
-If you don't have a network defined in the TOML you can still use the CLI by providing these 2 key parameter via cmd arg.
+If you don't have a network defined in the TOML you can still use the CLI by providing the RPC url via cmd arg.
 
 Then check the stats for the last N blocks
 ```bash
-SETH_CONFIG_PATH=seth.toml seth -c 327172 -u "https://my-rpc.network.io" stats -s -10
+seth -u "https://my-rpc.network.io" stats -s -10
 ```
 
 To check stats for the interval (A, B)
 ```bash
-SETH_CONFIG_PATH=seth.toml seth -c 327172 -u "https://my-rpc.network.io" stats -s A -e B
+SETH_CONFIG_PATH=seth.toml seth -u "https://my-rpc.network.io" stats -s A -e B
 ```
 
 Results can help you to understand if network is stable, what is avg block time, gas price, block utilization and transactions per second
@@ -323,7 +323,7 @@ SETH_CONFIG_PATH=seth.toml go run cmd/seth/seth.go -n=Geth trace -f reverted_tra
 
 or using cmd args
 ```
-SETH_CONFIG_PATH=seth.toml go run cmd/seth/seth.go -c 327172 -u "https://my-rpc.network.io" trace -f reverted_transactions.json
+SETH_CONFIG_PATH=seth.toml go run cmd/seth/seth.go -u "https://my-rpc.network.io" trace -f reverted_transactions.json
 ```
 
 You need to pass a file with a list of transaction hashes to trace. The file should be a JSON array of transaction hashes, like this:

--- a/client.go
+++ b/client.go
@@ -237,7 +237,7 @@ func NewClientRaw(
 		return nil, fmt.Errorf("failed to connect to '%s' due to: %w", cfg.Network.URLs[0], err)
 	}
 
-	if cfg.Network.ChainID == DefaultChainID {
+	if cfg.Network.Name == DefaultNetworkName {
 		chainId, err := client.ChainID(context.Background())
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to get chain ID")

--- a/client.go
+++ b/client.go
@@ -236,6 +236,15 @@ func NewClientRaw(
 	if err != nil {
 		return nil, fmt.Errorf("failed to connect to '%s' due to: %w", cfg.Network.URLs[0], err)
 	}
+
+	if cfg.Network.ChainID == DefaultChainID {
+		chainId, err := client.ChainID(context.Background())
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to get chain ID")
+		}
+		cfg.Network.ChainID = chainId.String()
+	}
+
 	cID, err := strconv.Atoi(cfg.Network.ChainID)
 	if err != nil {
 		return nil, err

--- a/client_api_test.go
+++ b/client_api_test.go
@@ -208,7 +208,7 @@ func TestAPIKeys(t *testing.T) {
 	_ = os.Remove(keyFilePath)
 	_ = os.Setenv(seth.KEYFILE_PATH_ENV_VAR, keyFilePath)
 
-	err := sethcmd.RunCLI([]string{"seth", "-n", os.Getenv(seth.NETWORK_ENV_VAR), "keys", "split", "-a", "60"})
+	err := sethcmd.RunCLI([]string{"seth", "-n", os.Getenv(seth.NETWORK_ENV_VAR), "keys", "fund", "-a", "60"})
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		err = sethcmd.RunCLI([]string{"seth", "-n", os.Getenv(seth.NETWORK_ENV_VAR), "keys", "return"})
@@ -290,7 +290,7 @@ func TestAPISyncKeysPool(t *testing.T) {
 			t.Setenv(seth.LogLevelEnvVar, "trace")
 			if !tc.ephemeral {
 				t.Setenv(seth.KEYFILE_PATH_ENV_VAR, keyfilePath)
-				err := sethcmd.RunCLI([]string{"seth", "-n", os.Getenv(seth.NETWORK_ENV_VAR), "keys", "split", "-a", strconv.Itoa(tc.keys)})
+				err := sethcmd.RunCLI([]string{"seth", "-n", os.Getenv(seth.NETWORK_ENV_VAR), "keys", "fund", "-a", strconv.Itoa(tc.keys)})
 				require.NoError(t, err)
 				t.Cleanup(func() {
 					err = sethcmd.RunCLI([]string{"seth", "-n", os.Getenv(seth.NETWORK_ENV_VAR), "keys", "return"})

--- a/cmd/seth.go
+++ b/cmd/seth.go
@@ -309,7 +309,7 @@ func RunCLI(args []string) error {
 						}
 						defer client.Close()
 
-						if cfg.Network.ChainID == seth.DefaultChainID {
+						if cfg.Network.ChainID == seth.DefaultNetworkName {
 							chainId, err := client.ChainID(context.Background())
 							if err != nil {
 								return errors.Wrap(err, "failed to get chain ID")

--- a/cmd/seth.go
+++ b/cmd/seth.go
@@ -1,7 +1,9 @@
 package seth
 
 import (
+	"context"
 	"fmt"
+	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/pelletier/go-toml/v2"
 	"github.com/pkg/errors"
 	"github.com/smartcontractkit/seth"
@@ -26,20 +28,17 @@ func RunCLI(args []string) error {
 		Flags: []cli.Flag{
 			&cli.StringFlag{Name: "networkName", Aliases: []string{"n"}},
 			&cli.StringFlag{Name: "url", Aliases: []string{"u"}},
-			&cli.StringFlag{Name: "chainId", Aliases: []string{"c"}},
 		},
 		Before: func(cCtx *cli.Context) error {
 			networkName := cCtx.String("networkName")
 			url := cCtx.String("url")
-			chainId := cCtx.String("chainId")
-			if networkName == "" && (url == "" && chainId == "") {
+			if networkName == "" && url == "" {
 				return errors.New(ErrNoNetwork)
 			}
 			if networkName != "" {
 				_ = os.Setenv(seth.NETWORK_ENV_VAR, networkName)
 			} else {
 				_ = os.Setenv(seth.URL_ENV_VAR, url)
-				_ = os.Setenv(seth.CHAIN_ID_ENV_VAR, chainId)
 			}
 			if cCtx.Args().Len() > 0 && cCtx.Args().First() != "trace" {
 				var err error
@@ -194,10 +193,10 @@ func RunCLI(args []string) error {
 						},
 					},
 					{
-						Name:        "split",
-						HelpName:    "split",
-						Aliases:     []string{"s"},
-						Description: "create a new key file, split all the funds from the root account to new keys",
+						Name:        "fund",
+						HelpName:    "fund",
+						Aliases:     []string{"f"},
+						Description: "create a new key file, split the funds from the root account to new keys OR fund existing keys read from keyfile",
 						ArgsUsage:   "-a ${amount of addresses to create} -b ${amount in ethers to keep in root key}",
 						Flags: []cli.Flag{
 							&cli.Int64Flag{Name: "addresses", Aliases: []string{"a"}},
@@ -284,11 +283,10 @@ func RunCLI(args []string) error {
 							return fmt.Errorf("network %s not defined in the TOML file", snet)
 						}
 					} else {
-						chainId := os.Getenv(seth.CHAIN_ID_ENV_VAR)
 						url := os.Getenv(seth.URL_ENV_VAR)
 
-						if chainId == "" || url == "" {
-							return fmt.Errorf("network not selected, set %s=... or %s=... and %s=..., check TOML config for available networks", seth.NETWORK_ENV_VAR, seth.CHAIN_ID_ENV_VAR, seth.URL_ENV_VAR)
+						if url == "" {
+							return fmt.Errorf("network not selected, set %s=... or %s=..., check TOML config for available networks", seth.NETWORK_ENV_VAR, seth.URL_ENV_VAR)
 						}
 
 						//look for default network
@@ -296,7 +294,6 @@ func RunCLI(args []string) error {
 							if n.Name == seth.DefaultNetworkName {
 								cfg.Network = n
 								cfg.Network.Name = snet
-								cfg.Network.ChainID = chainId
 								cfg.Network.URLs = []string{url}
 								break
 							}
@@ -304,6 +301,20 @@ func RunCLI(args []string) error {
 
 						if cfg.Network == nil {
 							return fmt.Errorf("default network not defined in the TOML file")
+						}
+
+						client, err := ethclient.Dial(cfg.Network.URLs[0])
+						if err != nil {
+							return fmt.Errorf("failed to connect to '%s' due to: %w", cfg.Network.URLs[0], err)
+						}
+						defer client.Close()
+
+						if cfg.Network.ChainID == seth.DefaultChainID {
+							chainId, err := client.ChainID(context.Background())
+							if err != nil {
+								return errors.Wrap(err, "failed to get chain ID")
+							}
+							cfg.Network.ChainID = chainId.String()
 						}
 					}
 

--- a/config.go
+++ b/config.go
@@ -34,7 +34,6 @@ const (
 	URL_ENV_VAR              = "SETH_URL"
 
 	DefaultNetworkName = "Default"
-	DefaultChainID     = "-1"
 )
 
 type KeyFileSource string

--- a/config.go
+++ b/config.go
@@ -31,7 +31,6 @@ const (
 
 	ROOT_PRIVATE_KEY_ENV_VAR = "SETH_ROOT_PRIVATE_KEY"
 	NETWORK_ENV_VAR          = "SETH_NETWORK"
-	CHAIN_ID_ENV_VAR         = "SETH_CHAIN_ID"
 	URL_ENV_VAR              = "SETH_URL"
 
 	DefaultNetworkName = "Default"
@@ -127,11 +126,10 @@ func ReadConfig() (*Config, error) {
 			return nil, fmt.Errorf("network %s not defined in the TOML file", snet)
 		}
 	} else {
-		chainId := os.Getenv(CHAIN_ID_ENV_VAR)
 		url := os.Getenv(URL_ENV_VAR)
 
-		if chainId == "" || url == "" {
-			return nil, fmt.Errorf("network not selected, set %s=... or %s=... and %s=..., check TOML config for available networks", NETWORK_ENV_VAR, CHAIN_ID_ENV_VAR, URL_ENV_VAR)
+		if url == "" {
+			return nil, fmt.Errorf("network not selected, set %s=... or %s=..., check TOML config for available networks", NETWORK_ENV_VAR, URL_ENV_VAR)
 		}
 
 		//look for default network
@@ -139,7 +137,6 @@ func ReadConfig() (*Config, error) {
 			if n.Name == DefaultNetworkName {
 				cfg.Network = n
 				cfg.Network.Name = DefaultNetworkName
-				cfg.Network.ChainID = chainId
 				cfg.Network.URLs = []string{url}
 				break
 			}
@@ -231,6 +228,9 @@ func readKeyFileConfig(cfg *Config) error {
 	err = toml.Unmarshal(kfd, &kf)
 	if err != nil {
 		return errors.Wrap(err, ErrUnmarshalKeyFileConfig)
+	}
+	if kf == nil {
+		return errors.New(ErrEmptyKeyFile)
 	}
 	for _, pk := range kf.Keys {
 		cfg.Network.PrivateKeys = append(cfg.Network.PrivateKeys, pk.PrivateKey)

--- a/examples/example_test.go
+++ b/examples/example_test.go
@@ -45,7 +45,7 @@ func setup(t *testing.T) *network_debug_contract.NetworkDebugContract {
 func commonMultiKeySetup(t *testing.T) {
 	_ = os.Remove("keyfile_test_example.toml")
 	t.Setenv(seth.KEYFILE_PATH_ENV_VAR, "keyfile_test_example.toml")
-	err := sethcmd.RunCLI([]string{"seth", "-n", os.Getenv(seth.NETWORK_ENV_VAR), "keys", "split", "-a", "2"})
+	err := sethcmd.RunCLI([]string{"seth", "-n", os.Getenv(seth.NETWORK_ENV_VAR), "keys", "fund", "-a", "2"})
 	require.NoError(t, err)
 }
 

--- a/keyfile.go
+++ b/keyfile.go
@@ -56,8 +56,16 @@ func UpdateAndSplitFunds(c *Client, opts *FundKeyFileCmdOpts) error {
 	for _, kfd := range keyFile.Keys {
 		kfd := kfd
 		eg.Go(func() error {
-			kfd.Funds = bd.AddrFunding.String()
-			return c.TransferETHFromKey(egCtx, 0, kfd.Address, bd.AddrFunding, gasPrice)
+			err := c.TransferETHFromKey(egCtx, 0, kfd.Address, bd.AddrFunding, gasPrice)
+			if err != nil {
+				return err
+			}
+			bal, err := c.Client.BalanceAt(egCtx, common.HexToAddress(kfd.Address), nil)
+			if err != nil {
+				return err
+			}
+			kfd.Funds = bal.String()
+			return nil
 		})
 	}
 	if err := eg.Wait(); err != nil {

--- a/keyfile_cli_test.go
+++ b/keyfile_cli_test.go
@@ -39,7 +39,7 @@ func TestCLIFundAndReturn(t *testing.T) {
 		}
 		bd, err := c.CalculateSubKeyFunding(10, gasPrice.Int64(), 10)
 		require.NoError(t, err, "Error calculating subkey funding")
-		err = sethcmd.RunCLI([]string{"seth", "-n", os.Getenv(seth.NETWORK_ENV_VAR), "keys", "split", "-a", "10", "-b", "10"})
+		err = sethcmd.RunCLI([]string{"seth", "-n", os.Getenv(seth.NETWORK_ENV_VAR), "keys", "fund", "-a", "10", "-b", "10"})
 		require.NoError(t, err, "Error splitting keys")
 		AssertFileBalances(t, bd.AddrFunding, keyFilePath)
 		err = sethcmd.RunCLI([]string{"seth", "-n", os.Getenv(seth.NETWORK_ENV_VAR), "keys", "return"})
@@ -53,7 +53,7 @@ func TestCLIUpdateBalances(t *testing.T) {
 	_ = os.Remove(keyFilePath)
 	err := os.Setenv(seth.KEYFILE_PATH_ENV_VAR, keyFilePath)
 	require.NoError(t, err)
-	err = sethcmd.RunCLI([]string{"seth", "-n", os.Getenv(seth.NETWORK_ENV_VAR), "keys", "split", "-a", "2", "-b", "10"})
+	err = sethcmd.RunCLI([]string{"seth", "-n", os.Getenv(seth.NETWORK_ENV_VAR), "keys", "fund", "-a", "2", "-b", "10"})
 	require.NoError(t, err)
 	c := newClientWithKeyfile(t, keyFilePath)
 	_, err = c.Decode(

--- a/network_cli_test.go
+++ b/network_cli_test.go
@@ -19,7 +19,7 @@ func TestCLINetworkFromEnv(t *testing.T) {
 	require.NoError(t, err, "Error unsetting env var")
 	err = os.Unsetenv(seth.URL_ENV_VAR)
 	require.NoError(t, err, "Error unsetting env var")
-	err = sethcmd.RunCLI([]string{"seth", "-n", network, "keys", "split", "-a", "10", "-b", "10"})
+	err = sethcmd.RunCLI([]string{"seth", "-n", network, "keys", "fund", "-a", "10", "-b", "10"})
 	require.NoError(t, err, "Error splitting keys")
 }
 
@@ -32,7 +32,7 @@ func TestCLIDefaultNetwork(t *testing.T) {
 	}()
 	err = os.Unsetenv(seth.NETWORK_ENV_VAR)
 	require.NoError(t, err, "Error unsetting env var")
-	err = sethcmd.RunCLI([]string{"seth", "-u", url, "keys", "split", "-a", "10", "-b", "10"})
+	err = sethcmd.RunCLI([]string{"seth", "-u", url, "keys", "fund", "-a", "10", "-b", "10"})
 	require.NoError(t, err, "Error splitting keys")
 }
 
@@ -45,7 +45,7 @@ func TestCLIDefaultNetworkNoUrl(t *testing.T) {
 	require.NoError(t, err, "Error unsetting env var")
 	err = os.Unsetenv(seth.URL_ENV_VAR)
 	require.NoError(t, err, "Error unsetting env var")
-	err = sethcmd.RunCLI([]string{"seth", "keys", "split", "-a", "10", "-b", "10"})
+	err = sethcmd.RunCLI([]string{"seth", "keys", "fund", "-a", "10", "-b", "10"})
 	require.Error(t, err, "No error when splitting keys without url")
 }
 
@@ -59,7 +59,7 @@ func TestCLITestDefaultNetworkNoUrlNorNetworkName(t *testing.T) {
 	err = os.Unsetenv(seth.URL_ENV_VAR)
 	require.NoError(t, err, "Error unsetting env var")
 
-	err = sethcmd.RunCLI([]string{"seth", "keys", "split", "-a", "10", "-b", "10"})
+	err = sethcmd.RunCLI([]string{"seth", "keys", "fund", "-a", "10", "-b", "10"})
 	require.Error(t, err, "No error when splitting keys without url or network name")
 }
 

--- a/network_cli_test.go
+++ b/network_cli_test.go
@@ -17,8 +17,6 @@ func TestCLINetworkFromEnv(t *testing.T) {
 	}()
 	err := os.Unsetenv(seth.NETWORK_ENV_VAR)
 	require.NoError(t, err, "Error unsetting env var")
-	err = os.Unsetenv(seth.CHAIN_ID_ENV_VAR)
-	require.NoError(t, err, "Error unsetting env var")
 	err = os.Unsetenv(seth.URL_ENV_VAR)
 	require.NoError(t, err, "Error unsetting env var")
 	err = sethcmd.RunCLI([]string{"seth", "-n", network, "keys", "split", "-a", "10", "-b", "10"})
@@ -26,53 +24,19 @@ func TestCLINetworkFromEnv(t *testing.T) {
 }
 
 func TestCLIDefaultNetwork(t *testing.T) {
-	url, chainId, err := getUrlAndChainIdFromEnv()
-	require.NoError(t, err, "Error getting URL and chain ID from env")
+	url, err := getUrlFromEnv()
+	require.NoError(t, err, "Error getting url from env")
 	network := os.Getenv(seth.NETWORK_ENV_VAR)
 	defer func() {
 		_ = os.Setenv(seth.NETWORK_ENV_VAR, network)
 	}()
 	err = os.Unsetenv(seth.NETWORK_ENV_VAR)
 	require.NoError(t, err, "Error unsetting env var")
-	err = sethcmd.RunCLI([]string{"seth", "-c", chainId, "-u", url, "keys", "split", "-a", "10", "-b", "10"})
+	err = sethcmd.RunCLI([]string{"seth", "-u", url, "keys", "split", "-a", "10", "-b", "10"})
 	require.NoError(t, err, "Error splitting keys")
 }
 
 func TestCLIDefaultNetworkNoUrl(t *testing.T) {
-	_, chainId, err := getUrlAndChainIdFromEnv()
-	require.NoError(t, err, "Error getting URL and chain ID from env")
-	network := os.Getenv(seth.NETWORK_ENV_VAR)
-	defer func() {
-		_ = os.Setenv(seth.NETWORK_ENV_VAR, network)
-	}()
-	err = os.Unsetenv(seth.NETWORK_ENV_VAR)
-	require.NoError(t, err, "Error unsetting env var")
-	err = os.Unsetenv(seth.CHAIN_ID_ENV_VAR)
-	require.NoError(t, err, "Error unsetting env var")
-	err = os.Unsetenv(seth.URL_ENV_VAR)
-	require.NoError(t, err, "Error unsetting env var")
-	err = sethcmd.RunCLI([]string{"seth", "-c", chainId, "keys", "split", "-a", "10", "-b", "10"})
-	require.Error(t, err, "No error when splitting keys without URL")
-}
-
-func TestCLITestDefaultNetworkNoChainID(t *testing.T) {
-	url, _, err := getUrlAndChainIdFromEnv()
-	require.NoError(t, err, "Error getting URL and chain ID from env")
-	network := os.Getenv(seth.NETWORK_ENV_VAR)
-	defer func() {
-		_ = os.Setenv(seth.NETWORK_ENV_VAR, network)
-	}()
-	err = os.Unsetenv(seth.NETWORK_ENV_VAR)
-	require.NoError(t, err, "Error unsetting env var")
-	err = os.Unsetenv(seth.CHAIN_ID_ENV_VAR)
-	require.NoError(t, err, "Error unsetting env var")
-	err = os.Unsetenv(seth.URL_ENV_VAR)
-	require.NoError(t, err, "Error unsetting env var")
-	err = sethcmd.RunCLI([]string{"seth", "-u", url, "keys", "split", "-a", "10", "-b", "10"})
-	require.Error(t, err, "No error when splitting keys without URL")
-}
-
-func TestCLITestDefaultNetworkNoChainIDNoUrlNorNetworkName(t *testing.T) {
 	network := os.Getenv(seth.NETWORK_ENV_VAR)
 	defer func() {
 		_ = os.Setenv(seth.NETWORK_ENV_VAR, network)
@@ -81,22 +45,31 @@ func TestCLITestDefaultNetworkNoChainIDNoUrlNorNetworkName(t *testing.T) {
 	require.NoError(t, err, "Error unsetting env var")
 	err = os.Unsetenv(seth.URL_ENV_VAR)
 	require.NoError(t, err, "Error unsetting env var")
-	err = os.Unsetenv(seth.CHAIN_ID_ENV_VAR)
+	err = sethcmd.RunCLI([]string{"seth", "keys", "split", "-a", "10", "-b", "10"})
+	require.Error(t, err, "No error when splitting keys without url")
+}
+
+func TestCLITestDefaultNetworkNoUrlNorNetworkName(t *testing.T) {
+	network := os.Getenv(seth.NETWORK_ENV_VAR)
+	defer func() {
+		_ = os.Setenv(seth.NETWORK_ENV_VAR, network)
+	}()
+	err := os.Unsetenv(seth.NETWORK_ENV_VAR)
+	require.NoError(t, err, "Error unsetting env var")
+	err = os.Unsetenv(seth.URL_ENV_VAR)
 	require.NoError(t, err, "Error unsetting env var")
 
 	err = sethcmd.RunCLI([]string{"seth", "keys", "split", "-a", "10", "-b", "10"})
-	require.Error(t, err, "No error when splitting keys without URL and chain ID")
+	require.Error(t, err, "No error when splitting keys without url or network name")
 }
 
-func getUrlAndChainIdFromEnv() (url, chainId string, err error) {
+func getUrlFromEnv() (url string, err error) {
 	network := os.Getenv(seth.NETWORK_ENV_VAR)
 	switch network {
 	case "Geth":
 		url = "ws://localhost:8546"
-		chainId = "1337"
 	case "Anvil":
 		url = "ws://localhost:8545"
-		chainId = "31337"
 	default:
 		err = fmt.Errorf("unsupported network : %s", network)
 	}

--- a/util.go
+++ b/util.go
@@ -153,7 +153,7 @@ func (m *Client) CreateOrUnmarshalKeyFile(opts *FundKeyFileCmdOpts) (*KeyFile, e
 		L.Info().
 			Str("Path", m.Cfg.KeyFilePath).
 			Interface("Opts", opts).
-			Msg("Loading keyfile")
+			Msg("Loading keyfile. Ignoring addresses-related opts")
 		var kf *KeyFile
 		d, err := os.ReadFile(m.Cfg.KeyFilePath)
 		if err != nil {


### PR DESCRIPTION
* rename keys CLI split to funds
* remove chain_id cli arg and get it from RPC node
* update readme

tested following commands:
* `keys fund` with new keyfile and existing
* `keys update`
* `keys return`

Tested on networks:
* Geth
* Polygon Amoy
* Wemix testnet
* Ethereum Sepolia